### PR TITLE
Add max_context_length to TextEncode node for LLM max tokens - experimental use

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -5,21 +5,26 @@ import gc
 from .utils import log, print_memory
 from diffusers.video_processor import VideoProcessor
 from typing import List, Dict, Any, Tuple
+import logging
 
 from .hyvideo.constants import PROMPT_TEMPLATE
 from .hyvideo.text_encoder import TextEncoder
 from .hyvideo.utils.data_utils import align_to
 from .hyvideo.diffusion.schedulers import FlowMatchDiscreteScheduler
 
-from .hyvideo.diffusion.schedulers.scheduling_dpmsolver_multistep import DPMSolverMultistepScheduler
+from .hyvideo.diffusion.schedulers.scheduling_dpmsolver_multistep import (
+    DPMSolverMultistepScheduler,
+)
 from .hyvideo.diffusion.schedulers.scheduling_sasolver import SASolverScheduler
-from. hyvideo.diffusion.schedulers.scheduling_unipc_multistep import UniPCMultistepScheduler
+from .hyvideo.diffusion.schedulers.scheduling_unipc_multistep import (
+    UniPCMultistepScheduler,
+)
 
-# from diffusers.schedulers import ( 
-#     DDIMScheduler, 
-#     PNDMScheduler, 
-#     DPMSolverMultistepScheduler, 
-#     EulerDiscreteScheduler, 
+# from diffusers.schedulers import (
+#     DDIMScheduler,
+#     PNDMScheduler,
+#     DPMSolverMultistepScheduler,
+#     EulerDiscreteScheduler,
 #     EulerAncestralDiscreteScheduler,
 #     UniPCMultistepScheduler,
 #     HeunDiscreteScheduler,
@@ -27,6 +32,10 @@ from. hyvideo.diffusion.schedulers.scheduling_unipc_multistep import UniPCMultis
 #     DEISMultistepScheduler,
 #     LCMScheduler
 #     )
+
+# --- Logging Configuration ---
+# Set to DEBUG to see detailed information, INFO for normal operation
+log.setLevel(logging.INFO)
 
 scheduler_mapping = {
     "FlowMatchDiscreteScheduler": FlowMatchDiscreteScheduler,
@@ -44,7 +53,10 @@ from accelerate import init_empty_weights
 from accelerate.utils import set_module_tensor_to_device
 
 import folder_paths
-folder_paths.add_model_folder_path("hyvid_embeds", os.path.join(folder_paths.get_output_directory(), "hyvid_embeds"))
+
+folder_paths.add_model_folder_path(
+    "hyvid_embeds", os.path.join(folder_paths.get_output_directory(), "hyvid_embeds")
+)
 
 import comfy.model_management as mm
 from comfy.utils import load_torch_file, save_torch_file
@@ -55,27 +67,30 @@ script_directory = os.path.dirname(os.path.abspath(__file__))
 
 VAE_SCALING_FACTOR = 0.476986
 
+
 def filter_state_dict_by_blocks(state_dict, blocks_mapping):
     filtered_dict = {}
 
     for key in state_dict:
-        if 'double_blocks.' in key or 'single_blocks.' in key:
-            block_pattern = key.split('diffusion_model.')[1].split('.', 2)[0:2]
-            block_key = f'{block_pattern[0]}.{block_pattern[1]}.'
+        if "double_blocks." in key or "single_blocks." in key:
+            block_pattern = key.split("diffusion_model.")[1].split(".", 2)[0:2]
+            block_key = f"{block_pattern[0]}.{block_pattern[1]}."
 
             if block_key in blocks_mapping:
                 filtered_dict[key] = state_dict[key]
 
     return filtered_dict
 
+
 def standardize_lora_key_format(lora_sd):
     new_sd = {}
     for k, v in lora_sd.items():
         # Diffusers format
-        if k.startswith('transformer.'):
-            k = k.replace('transformer.', 'diffusion_model.')
+        if k.startswith("transformer."):
+            k = k.replace("transformer.", "diffusion_model.")
         new_sd[k] = v
     return new_sd
+
 
 class HyVideoLoraBlockEdit:
     def __init__(self):
@@ -94,8 +109,8 @@ class HyVideoLoraBlockEdit:
 
         return {"required": arg_dict}
 
-    RETURN_TYPES = ("SELECTEDBLOCKS", )
-    RETURN_NAMES = ("blocks", )
+    RETURN_TYPES = ("SELECTEDBLOCKS",)
+    RETURN_NAMES = ("blocks",)
     OUTPUT_TOOLTIPS = ("The modified diffusion model.",)
     FUNCTION = "select"
 
@@ -105,23 +120,41 @@ class HyVideoLoraBlockEdit:
         selected_blocks = {k: v for k, v in kwargs.items() if v is True}
         print("Selected blocks: ", selected_blocks)
         return (selected_blocks,)
+
+
 class HyVideoLoraSelect:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-               "lora": (folder_paths.get_filename_list("loras"),
-                {"tooltip": "LORA models are expected to be in ComfyUI/models/loras with .safetensors extension"}),
-                "strength": ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.0001, "tooltip": "LORA strength, set to 0.0 to unmerge the LORA"}),
+                "lora": (
+                    folder_paths.get_filename_list("loras"),
+                    {
+                        "tooltip": "LORA models are expected to be in ComfyUI/models/loras with .safetensors extension"
+                    },
+                ),
+                "strength": (
+                    "FLOAT",
+                    {
+                        "default": 1.0,
+                        "min": -10.0,
+                        "max": 10.0,
+                        "step": 0.0001,
+                        "tooltip": "LORA strength, set to 0.0 to unmerge the LORA",
+                    },
+                ),
             },
             "optional": {
-                "prev_lora":("HYVIDLORA", {"default": None, "tooltip": "For loading multiple LoRAs"}),
-                "blocks":("SELECTEDBLOCKS", ),
-            }
+                "prev_lora": (
+                    "HYVIDLORA",
+                    {"default": None, "tooltip": "For loading multiple LoRAs"},
+                ),
+                "blocks": ("SELECTEDBLOCKS",),
+            },
         }
 
     RETURN_TYPES = ("HYVIDLORA",)
-    RETURN_NAMES = ("lora", )
+    RETURN_NAMES = ("lora",)
     FUNCTION = "getlorapath"
     CATEGORY = "HunyuanVideoWrapper"
     DESCRIPTION = "Select a LoRA model from ComfyUI/models/loras"
@@ -134,7 +167,7 @@ class HyVideoLoraSelect:
             "strength": strength,
             "name": lora.split(".")[0],
             "fuse_lora": fuse_lora,
-            "blocks": blocks
+            "blocks": blocks,
         }
         if prev_lora is not None:
             loras_list.extend(prev_lora)
@@ -142,38 +175,107 @@ class HyVideoLoraSelect:
         loras_list.append(lora)
         return (loras_list,)
 
+
 class HyVideoBlockSwap:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "double_blocks_to_swap": ("INT", {"default": 20, "min": 0, "max": 20, "step": 1, "tooltip": "Number of double blocks to swap"}),
-                "single_blocks_to_swap": ("INT", {"default": 0, "min": 0, "max": 40, "step": 1, "tooltip": "Number of single blocks to swap"}),
-                "offload_txt_in": ("BOOLEAN", {"default": False, "tooltip": "Offload txt_in layer"}),
-                "offload_img_in": ("BOOLEAN", {"default": False, "tooltip": "Offload img_in layer"}),
+                "double_blocks_to_swap": (
+                    "INT",
+                    {
+                        "default": 20,
+                        "min": 0,
+                        "max": 20,
+                        "step": 1,
+                        "tooltip": "Number of double blocks to swap",
+                    },
+                ),
+                "single_blocks_to_swap": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": 40,
+                        "step": 1,
+                        "tooltip": "Number of single blocks to swap",
+                    },
+                ),
+                "offload_txt_in": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Offload txt_in layer"},
+                ),
+                "offload_img_in": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Offload img_in layer"},
+                ),
             },
         }
+
     RETURN_TYPES = ("BLOCKSWAPARGS",)
     RETURN_NAMES = ("block_swap_args",)
     FUNCTION = "setargs"
     CATEGORY = "HunyuanVideoWrapper"
-    DESCRIPTION = "Settings for block swapping, reduces VRAM use by swapping blocks to CPU memory"
+    DESCRIPTION = (
+        "Settings for block swapping, reduces VRAM use by swapping blocks to CPU memory"
+    )
 
     def setargs(self, **kwargs):
-        return (kwargs, )
-    
+        return (kwargs,)
+
+
 class HyVideoEnhanceAVideo:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "weight": ("FLOAT", {"default": 2.0, "min": 0, "max": 100, "step": 0.01, "tooltip": "The feta Weight of the Enhance-A-Video"}),
-                "single_blocks": ("BOOLEAN", {"default": True, "tooltip": "Enable Enhance-A-Video for single blocks"}),
-                "double_blocks": ("BOOLEAN", {"default": True, "tooltip": "Enable Enhance-A-Video for double blocks"}),
-                "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01, "tooltip": "Start percentage of the steps to apply Enhance-A-Video"}),
-                "end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01, "tooltip": "End percentage of the steps to apply Enhance-A-Video"}),
+                "weight": (
+                    "FLOAT",
+                    {
+                        "default": 2.0,
+                        "min": 0,
+                        "max": 100,
+                        "step": 0.01,
+                        "tooltip": "The feta Weight of the Enhance-A-Video",
+                    },
+                ),
+                "single_blocks": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Enable Enhance-A-Video for single blocks",
+                    },
+                ),
+                "double_blocks": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Enable Enhance-A-Video for double blocks",
+                    },
+                ),
+                "start_percent": (
+                    "FLOAT",
+                    {
+                        "default": 0.0,
+                        "min": 0.0,
+                        "max": 1.0,
+                        "step": 0.01,
+                        "tooltip": "Start percentage of the steps to apply Enhance-A-Video",
+                    },
+                ),
+                "end_percent": (
+                    "FLOAT",
+                    {
+                        "default": 1.0,
+                        "min": 0.0,
+                        "max": 1.0,
+                        "step": 0.01,
+                        "tooltip": "End percentage of the steps to apply Enhance-A-Video",
+                    },
+                ),
             },
         }
+
     RETURN_TYPES = ("FETAARGS",)
     RETURN_NAMES = ("feta_args",)
     FUNCTION = "setargs"
@@ -181,7 +283,8 @@ class HyVideoEnhanceAVideo:
     DESCRIPTION = "https://github.com/NUS-HPC-AI-Lab/Enhance-A-Video"
 
     def setargs(self, **kwargs):
-        return (kwargs, )
+        return (kwargs,)
+
 
 class HyVideoSTG:
     @classmethod
@@ -189,12 +292,49 @@ class HyVideoSTG:
         return {
             "required": {
                 "stg_mode": (["STG-A", "STG-R"],),
-                "stg_block_idx": ("INT", {"default": 0, "min": -1, "max": 39, "step": 1, "tooltip": "Block index to apply STG"}),
-                "stg_scale": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.01, "tooltip": "Recommended values are ≤2.0"}),
-                "stg_start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01, "tooltip": "Start percentage of the steps to apply STG"}),
-                "stg_end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01, "tooltip": "End percentage of the steps to apply STG"}),
+                "stg_block_idx": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": -1,
+                        "max": 39,
+                        "step": 1,
+                        "tooltip": "Block index to apply STG",
+                    },
+                ),
+                "stg_scale": (
+                    "FLOAT",
+                    {
+                        "default": 1.0,
+                        "min": 0.0,
+                        "max": 10.0,
+                        "step": 0.01,
+                        "tooltip": "Recommended values are ≤2.0",
+                    },
+                ),
+                "stg_start_percent": (
+                    "FLOAT",
+                    {
+                        "default": 0.0,
+                        "min": 0.0,
+                        "max": 1.0,
+                        "step": 0.01,
+                        "tooltip": "Start percentage of the steps to apply STG",
+                    },
+                ),
+                "stg_end_percent": (
+                    "FLOAT",
+                    {
+                        "default": 1.0,
+                        "min": 0.0,
+                        "max": 1.0,
+                        "step": 0.01,
+                        "tooltip": "End percentage of the steps to apply STG",
+                    },
+                ),
             },
         }
+
     RETURN_TYPES = ("STGARGS",)
     RETURN_NAMES = ("stg_args",)
     FUNCTION = "setargs"
@@ -202,17 +342,27 @@ class HyVideoSTG:
     DESCRIPTION = "Spatio Temporal Guidance, https://github.com/junhahyung/STGuidance"
 
     def setargs(self, **kwargs):
-        return (kwargs, )
+        return (kwargs,)
+
 
 class HyVideoTeaCache:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "rel_l1_thresh": ("FLOAT", {"default": 0.15, "min": 0.0, "max": 1.0, "step": 0.01,
-                                            "tooltip": "Higher values will make TeaCache more aggressive, faster, but may cause artifacts"}),
+                "rel_l1_thresh": (
+                    "FLOAT",
+                    {
+                        "default": 0.15,
+                        "min": 0.0,
+                        "max": 1.0,
+                        "step": 0.01,
+                        "tooltip": "Higher values will make TeaCache more aggressive, faster, but may cause artifacts",
+                    },
+                ),
             },
         }
+
     RETURN_TYPES = ("TEACACHEARGS",)
     RETURN_NAMES = ("teacache_args",)
     FUNCTION = "process"
@@ -252,42 +402,89 @@ class HyVideoModelConfig:
         self.unet_config["disable_unet_model_creation"] = True
 
 
-#region Model loading
+# region Model loading
 class HyVideoModelLoader:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "model": (folder_paths.get_filename_list("diffusion_models"), {"tooltip": "These models are loaded from the 'ComfyUI/models/diffusion_models' -folder",}),
-
-            "base_precision": (["fp32", "bf16"], {"default": "bf16"}),
-            "quantization": (['disabled', 'fp8_e4m3fn', 'fp8_e4m3fn_fast', 'fp8_scaled', 'torchao_fp8dq', "torchao_fp8dqrow", "torchao_int8dq", "torchao_fp6", "torchao_int4", "torchao_int8"], {"default": 'disabled', "tooltip": "optional quantization method"}),
-            "load_device": (["main_device", "offload_device"], {"default": "main_device"}),
+                "model": (
+                    folder_paths.get_filename_list("diffusion_models"),
+                    {
+                        "tooltip": "These models are loaded from the 'ComfyUI/models/diffusion_models' -folder",
+                    },
+                ),
+                "base_precision": (["fp32", "bf16"], {"default": "bf16"}),
+                "quantization": (
+                    [
+                        "disabled",
+                        "fp8_e4m3fn",
+                        "fp8_e4m3fn_fast",
+                        "fp8_scaled",
+                        "torchao_fp8dq",
+                        "torchao_fp8dqrow",
+                        "torchao_int8dq",
+                        "torchao_fp6",
+                        "torchao_int4",
+                        "torchao_int8",
+                    ],
+                    {"default": "disabled", "tooltip": "optional quantization method"},
+                ),
+                "load_device": (
+                    ["main_device", "offload_device"],
+                    {"default": "main_device"},
+                ),
             },
             "optional": {
-                "attention_mode": ([
-                    "sdpa",
-                    "flash_attn_varlen",
-                    "sageattn_varlen",
-                    "comfy",
-                    ], {"default": "flash_attn"}),
-                "compile_args": ("COMPILEARGS", ),
-                "block_swap_args": ("BLOCKSWAPARGS", ),
+                "attention_mode": (
+                    [
+                        "sdpa",
+                        "flash_attn_varlen",
+                        "sageattn_varlen",
+                        "comfy",
+                    ],
+                    {"default": "flash_attn"},
+                ),
+                "compile_args": ("COMPILEARGS",),
+                "block_swap_args": ("BLOCKSWAPARGS",),
                 "lora": ("HYVIDLORA", {"default": None}),
-                "auto_cpu_offload": ("BOOLEAN", {"default": False, "tooltip": "Enable auto offloading for reduced VRAM usage, implementation from DiffSynth-Studio, slightly different from block swapping and uses even less VRAM, but can be slower as you can't define how much VRAM to use"}),
-                "upcast_rope": ("BOOLEAN", {"default": True, "tooltip": "Upcast RoPE to fp32 for better accuracy, this is the default behaviour, disabling can improve speed and reduce memory use slightly"}),
-            }
+                "auto_cpu_offload": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "tooltip": "Enable auto offloading for reduced VRAM usage, implementation from DiffSynth-Studio, slightly different from block swapping and uses even less VRAM, but can be slower as you can't define how much VRAM to use",
+                    },
+                ),
+                "upcast_rope": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Upcast RoPE to fp32 for better accuracy, this is the default behaviour, disabling can improve speed and reduce memory use slightly",
+                    },
+                ),
+            },
         }
 
     RETURN_TYPES = ("HYVIDEOMODEL",)
-    RETURN_NAMES = ("model", )
+    RETURN_NAMES = ("model",)
     FUNCTION = "loadmodel"
     CATEGORY = "HunyuanVideoWrapper"
 
-    def loadmodel(self, model, base_precision, load_device,  quantization,
-                  compile_args=None, attention_mode="sdpa", block_swap_args=None, lora=None, auto_cpu_offload=False, upcast_rope=True):
+    def loadmodel(
+        self,
+        model,
+        base_precision,
+        load_device,
+        quantization,
+        compile_args=None,
+        attention_mode="sdpa",
+        block_swap_args=None,
+        lora=None,
+        auto_cpu_offload=False,
+        upcast_rope=True,
+    ):
         transformer = None
-        #mm.unload_all_models()
+        # mm.unload_all_models()
         mm.soft_empty_cache()
         manual_offloading = True
         if "sage" in attention_mode:
@@ -299,9 +496,17 @@ class HyVideoModelLoader:
         device = mm.get_torch_device()
         offload_device = mm.unet_offload_device()
         manual_offloading = True
-        transformer_load_device = device if load_device == "main_device" else offload_device
-        
-        base_dtype = {"fp8_e4m3fn": torch.float8_e4m3fn, "fp8_e4m3fn_fast": torch.float8_e4m3fn, "bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[base_precision]
+        transformer_load_device = (
+            device if load_device == "main_device" else offload_device
+        )
+
+        base_dtype = {
+            "fp8_e4m3fn": torch.float8_e4m3fn,
+            "fp8_e4m3fn_fast": torch.float8_e4m3fn,
+            "bf16": torch.bfloat16,
+            "fp16": torch.float16,
+            "fp32": torch.float32,
+        }[base_precision]
 
         model_path = folder_paths.get_full_path_or_raise("diffusion_models", model)
         sd = load_torch_file(model_path, device=transformer_load_device, safe_load=True)
@@ -325,7 +530,7 @@ class HyVideoModelLoader:
                 main_device=device,
                 offload_device=offload_device,
                 **HUNYUAN_VIDEO_CONFIG,
-                **factor_kwargs
+                **factor_kwargs,
             )
         transformer.eval()
 
@@ -335,17 +540,17 @@ class HyVideoModelLoader:
             HyVideoModelConfig(base_dtype),
             model_type=comfy.model_base.ModelType.FLOW,
             device=device,
-        )        
-        
+        )
+
         scheduler_config = {
             "flow_shift": 9.0,
             "reverse": True,
             "solver": "euler",
-            "use_flow_sigmas": True, 
-            "prediction_type": 'flow_prediction'
+            "use_flow_sigmas": True,
+            "prediction_type": "flow_prediction",
         }
         scheduler = FlowMatchDiscreteScheduler.from_config(scheduler_config)
-        
+
         pipe = HunyuanVideoPipeline(
             transformer=transformer,
             scheduler=scheduler,
@@ -356,17 +561,41 @@ class HyVideoModelLoader:
 
         if not "torchao" in quantization:
             log.info("Using accelerate to load and assign model weights to device...")
-            if quantization == "fp8_e4m3fn" or quantization == "fp8_e4m3fn_fast" or quantization == "fp8_scaled":
+            if (
+                quantization == "fp8_e4m3fn"
+                or quantization == "fp8_e4m3fn_fast"
+                or quantization == "fp8_scaled"
+            ):
                 dtype = torch.float8_e4m3fn
             else:
                 dtype = base_dtype
-            params_to_keep = {"norm", "bias", "time_in", "vector_in", "guidance_in", "txt_in", "img_in"}
+            params_to_keep = {
+                "norm",
+                "bias",
+                "time_in",
+                "vector_in",
+                "guidance_in",
+                "txt_in",
+                "img_in",
+            }
             for name, param in transformer.named_parameters():
-                dtype_to_use = base_dtype if any(keyword in name for keyword in params_to_keep) else dtype
-                set_module_tensor_to_device(transformer, name, device=transformer_load_device, dtype=dtype_to_use, value=sd[name])
+                dtype_to_use = (
+                    base_dtype
+                    if any(keyword in name for keyword in params_to_keep)
+                    else dtype
+                )
+                set_module_tensor_to_device(
+                    transformer,
+                    name,
+                    device=transformer_load_device,
+                    dtype=dtype_to_use,
+                    value=sd[name],
+                )
 
             comfy_model.diffusion_model = transformer
-            patcher = comfy.model_patcher.ModelPatcher(comfy_model, device, offload_device)
+            patcher = comfy.model_patcher.ModelPatcher(
+                comfy_model, device, offload_device
+            )
             pipe.comfy_model = patcher
 
             del sd
@@ -375,8 +604,11 @@ class HyVideoModelLoader:
 
             if lora is not None:
                 from comfy.sd import load_lora_for_models
+
                 for l in lora:
-                    log.info(f"Loading LoRA: {l['name']} with strength: {l['strength']}")
+                    log.info(
+                        f"Loading LoRA: {l['name']} with strength: {l['strength']}"
+                    )
                     lora_path = l["path"]
                     lora_strength = l["strength"]
                     lora_sd = load_torch_file(lora_path, safe_load=True)
@@ -384,10 +616,12 @@ class HyVideoModelLoader:
                     if l["blocks"]:
                         lora_sd = filter_state_dict_by_blocks(lora_sd, l["blocks"])
 
-                    #for k in lora_sd.keys():
-                     #   print(k)
+                    # for k in lora_sd.keys():
+                    #   print(k)
 
-                    patcher, _ = load_lora_for_models(patcher, None, lora_sd, lora_strength, 0)
+                    patcher, _ = load_lora_for_models(
+                        patcher, None, lora_sd, lora_strength, 0
+                    )
 
             comfy.model_management.load_models_gpu([patcher])
             if load_device == "offload_device":
@@ -395,39 +629,81 @@ class HyVideoModelLoader:
 
             if quantization == "fp8_e4m3fn_fast":
                 from .fp8_optimization import convert_fp8_linear
-                convert_fp8_linear(patcher.model.diffusion_model, base_dtype, params_to_keep=params_to_keep)
+
+                convert_fp8_linear(
+                    patcher.model.diffusion_model,
+                    base_dtype,
+                    params_to_keep=params_to_keep,
+                )
             elif quantization == "fp8_scaled":
                 from .hyvideo.modules.fp8_optimization import convert_fp8_linear
+
                 convert_fp8_linear(patcher.model.diffusion_model, base_dtype)
 
             if auto_cpu_offload:
                 transformer.enable_auto_offload(dtype=dtype, device=device)
 
-            #compile
+            # compile
             if compile_args is not None:
-                torch._dynamo.config.cache_size_limit = compile_args["dynamo_cache_size_limit"]
+                torch._dynamo.config.cache_size_limit = compile_args[
+                    "dynamo_cache_size_limit"
+                ]
                 if compile_args["compile_single_blocks"]:
-                    for i, block in enumerate(patcher.model.diffusion_model.single_blocks):
-                        patcher.model.diffusion_model.single_blocks[i] = torch.compile(block, fullgraph=compile_args["fullgraph"], dynamic=compile_args["dynamic"], backend=compile_args["backend"], mode=compile_args["mode"])
+                    for i, block in enumerate(
+                        patcher.model.diffusion_model.single_blocks
+                    ):
+                        patcher.model.diffusion_model.single_blocks[i] = torch.compile(
+                            block,
+                            fullgraph=compile_args["fullgraph"],
+                            dynamic=compile_args["dynamic"],
+                            backend=compile_args["backend"],
+                            mode=compile_args["mode"],
+                        )
                 if compile_args["compile_double_blocks"]:
-                    for i, block in enumerate(patcher.model.diffusion_model.double_blocks):
-                        patcher.model.diffusion_model.double_blocks[i] = torch.compile(block, fullgraph=compile_args["fullgraph"], dynamic=compile_args["dynamic"], backend=compile_args["backend"], mode=compile_args["mode"])
+                    for i, block in enumerate(
+                        patcher.model.diffusion_model.double_blocks
+                    ):
+                        patcher.model.diffusion_model.double_blocks[i] = torch.compile(
+                            block,
+                            fullgraph=compile_args["fullgraph"],
+                            dynamic=compile_args["dynamic"],
+                            backend=compile_args["backend"],
+                            mode=compile_args["mode"],
+                        )
                 if compile_args["compile_txt_in"]:
-                    patcher.model.diffusion_model.txt_in = torch.compile(patcher.model.diffusion_model.txt_in, fullgraph=compile_args["fullgraph"], dynamic=compile_args["dynamic"], backend=compile_args["backend"], mode=compile_args["mode"])
+                    patcher.model.diffusion_model.txt_in = torch.compile(
+                        patcher.model.diffusion_model.txt_in,
+                        fullgraph=compile_args["fullgraph"],
+                        dynamic=compile_args["dynamic"],
+                        backend=compile_args["backend"],
+                        mode=compile_args["mode"],
+                    )
                 if compile_args["compile_vector_in"]:
-                    patcher.model.diffusion_model.vector_in = torch.compile(patcher.model.diffusion_model.vector_in, fullgraph=compile_args["fullgraph"], dynamic=compile_args["dynamic"], backend=compile_args["backend"], mode=compile_args["mode"])
+                    patcher.model.diffusion_model.vector_in = torch.compile(
+                        patcher.model.diffusion_model.vector_in,
+                        fullgraph=compile_args["fullgraph"],
+                        dynamic=compile_args["dynamic"],
+                        backend=compile_args["backend"],
+                        mode=compile_args["mode"],
+                    )
                 if compile_args["compile_final_layer"]:
-                    patcher.model.diffusion_model.final_layer = torch.compile(patcher.model.diffusion_model.final_layer, fullgraph=compile_args["fullgraph"], dynamic=compile_args["dynamic"], backend=compile_args["backend"], mode=compile_args["mode"])
+                    patcher.model.diffusion_model.final_layer = torch.compile(
+                        patcher.model.diffusion_model.final_layer,
+                        fullgraph=compile_args["fullgraph"],
+                        dynamic=compile_args["dynamic"],
+                        backend=compile_args["backend"],
+                        mode=compile_args["mode"],
+                    )
         elif "torchao" in quantization:
             try:
                 from torchao.quantization import (
-                quantize_,
-                fpx_weight_only,
-                float8_dynamic_activation_float8_weight,
-                int8_dynamic_activation_int8_weight,
-                int8_weight_only,
-                int4_weight_only
-            )
+                    quantize_,
+                    fpx_weight_only,
+                    float8_dynamic_activation_float8_weight,
+                    int8_dynamic_activation_int8_weight,
+                    int8_weight_only,
+                    int4_weight_only,
+                )
             except:
                 raise ImportError("torchao is not installed")
 
@@ -445,54 +721,92 @@ class HyVideoModelLoader:
                 quant_func = int8_weight_only()
             elif "fp8dq" in quantization:
                 quant_func = float8_dynamic_activation_float8_weight()
-            elif 'fp8dqrow' in quantization:
+            elif "fp8dqrow" in quantization:
                 from torchao.quantization.quant_api import PerRow
-                quant_func = float8_dynamic_activation_float8_weight(granularity=PerRow())
-            elif 'int8dq' in quantization:
+
+                quant_func = float8_dynamic_activation_float8_weight(
+                    granularity=PerRow()
+                )
+            elif "int8dq" in quantization:
                 quant_func = int8_dynamic_activation_int8_weight()
 
             log.info(f"Quantizing model with {quant_func}")
             comfy_model.diffusion_model = transformer
-            patcher = comfy.model_patcher.ModelPatcher(comfy_model, device, offload_device)
+            patcher = comfy.model_patcher.ModelPatcher(
+                comfy_model, device, offload_device
+            )
 
             if lora is not None:
                 from comfy.sd import load_lora_for_models
+
                 for l in lora:
                     lora_path = l["path"]
                     lora_strength = l["strength"]
                     lora_sd = load_torch_file(lora_path, safe_load=True)
                     lora_sd = standardize_lora_key_format(lora_sd)
-                    patcher, _ = load_lora_for_models(patcher, None, lora_sd, lora_strength, 0)
+                    patcher, _ = load_lora_for_models(
+                        patcher, None, lora_sd, lora_strength, 0
+                    )
 
             comfy.model_management.load_models_gpu([patcher])
 
             for i, block in enumerate(patcher.model.diffusion_model.single_blocks):
                 log.info(f"Quantizing single_block {i}")
                 for name, _ in block.named_parameters(prefix=f"single_blocks.{i}"):
-                    #print(f"Parameter name: {name}")
-                    set_module_tensor_to_device(patcher.model.diffusion_model, name, device=patcher.model.diffusion_model_load_device, dtype=base_dtype, value=sd[name])
+                    # print(f"Parameter name: {name}")
+                    set_module_tensor_to_device(
+                        patcher.model.diffusion_model,
+                        name,
+                        device=patcher.model.diffusion_model_load_device,
+                        dtype=base_dtype,
+                        value=sd[name],
+                    )
                 if compile_args is not None:
-                    patcher.model.diffusion_model.single_blocks[i] = torch.compile(block, fullgraph=compile_args["fullgraph"], dynamic=compile_args["dynamic"], backend=compile_args["backend"], mode=compile_args["mode"])
+                    patcher.model.diffusion_model.single_blocks[i] = torch.compile(
+                        block,
+                        fullgraph=compile_args["fullgraph"],
+                        dynamic=compile_args["dynamic"],
+                        backend=compile_args["backend"],
+                        mode=compile_args["mode"],
+                    )
                 quantize_(block, quant_func)
                 print(block)
                 block.to(offload_device)
             for i, block in enumerate(patcher.model.diffusion_model.double_blocks):
                 log.info(f"Quantizing double_block {i}")
                 for name, _ in block.named_parameters(prefix=f"double_blocks.{i}"):
-                    #print(f"Parameter name: {name}")
-                    set_module_tensor_to_device(patcher.model.diffusion_model, name, device=patcher.model.diffusion_model_load_device, dtype=base_dtype, value=sd[name])
+                    # print(f"Parameter name: {name}")
+                    set_module_tensor_to_device(
+                        patcher.model.diffusion_model,
+                        name,
+                        device=patcher.model.diffusion_model_load_device,
+                        dtype=base_dtype,
+                        value=sd[name],
+                    )
                 if compile_args is not None:
-                    patcher.model.diffusion_model.double_blocks[i] = torch.compile(block, fullgraph=compile_args["fullgraph"], dynamic=compile_args["dynamic"], backend=compile_args["backend"], mode=compile_args["mode"])
+                    patcher.model.diffusion_model.double_blocks[i] = torch.compile(
+                        block,
+                        fullgraph=compile_args["fullgraph"],
+                        dynamic=compile_args["dynamic"],
+                        backend=compile_args["backend"],
+                        mode=compile_args["mode"],
+                    )
                 quantize_(block, quant_func)
             for name, param in patcher.model.diffusion_model.named_parameters():
                 if "single_blocks" not in name and "double_blocks" not in name:
-                    set_module_tensor_to_device(patcher.model.diffusion_model, name, device=patcher.model.diffusion_model_load_device, dtype=base_dtype, value=sd[name])
+                    set_module_tensor_to_device(
+                        patcher.model.diffusion_model,
+                        name,
+                        device=patcher.model.diffusion_model_load_device,
+                        dtype=base_dtype,
+                        value=sd[name],
+                    )
 
-            manual_offloading = False # to disable manual .to(device) calls
+            manual_offloading = False  # to disable manual .to(device) calls
             log.info(f"Quantized transformer blocks to {quantization}")
             for name, param in patcher.model.diffusion_model.named_parameters():
                 print(name, param.dtype)
-                #param.data = param.data.to(self.vae_dtype).to(device)
+                # param.data = param.data.to(self.vae_dtype).to(device)
 
             del sd
             mm.soft_empty_cache()
@@ -509,36 +823,40 @@ class HyVideoModelLoader:
 
         return (patcher,)
 
-#region load VAE
+
+# region load VAE
+
 
 class HyVideoVAELoader:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "model_name": (folder_paths.get_filename_list("vae"), {"tooltip": "These models are loaded from 'ComfyUI/models/vae'"}),
+                "model_name": (
+                    folder_paths.get_filename_list("vae"),
+                    {"tooltip": "These models are loaded from 'ComfyUI/models/vae'"},
+                ),
             },
             "optional": {
-                "precision": (["fp16", "fp32", "bf16"],
-                    {"default": "bf16"}
-                ),
-                "compile_args":("COMPILEARGS", ),
-            }
+                "precision": (["fp16", "fp32", "bf16"], {"default": "bf16"}),
+                "compile_args": ("COMPILEARGS",),
+            },
         }
 
     RETURN_TYPES = ("VAE",)
-    RETURN_NAMES = ("vae", )
+    RETURN_NAMES = ("vae",)
     FUNCTION = "loadmodel"
     CATEGORY = "HunyuanVideoWrapper"
     DESCRIPTION = "Loads Hunyuan VAE model from 'ComfyUI/models/vae'"
 
     def loadmodel(self, model_name, precision, compile_args=None):
-
         device = mm.get_torch_device()
         offload_device = mm.unet_offload_device()
 
-        dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[precision]
-        with open(os.path.join(script_directory, 'configs', 'hy_vae_config.json')) as f:
+        dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[
+            precision
+        ]
+        with open(os.path.join(script_directory, "configs", "hy_vae_config.json")) as f:
             vae_config = json.load(f)
         model_path = folder_paths.get_full_path("vae", model_name)
         vae_sd = load_torch_file(model_path, safe_load=True)
@@ -548,16 +866,22 @@ class HyVideoVAELoader:
         del vae_sd
         vae.requires_grad_(False)
         vae.eval()
-        vae.to(device = device, dtype = dtype)
+        vae.to(device=device, dtype=dtype)
 
-        #compile
+        # compile
         if compile_args is not None:
-            torch._dynamo.config.cache_size_limit = compile_args["dynamo_cache_size_limit"]
-            vae = torch.compile(vae, fullgraph=compile_args["fullgraph"], dynamic=compile_args["dynamic"], backend=compile_args["backend"], mode=compile_args["mode"])
-            
+            torch._dynamo.config.cache_size_limit = compile_args[
+                "dynamo_cache_size_limit"
+            ]
+            vae = torch.compile(
+                vae,
+                fullgraph=compile_args["fullgraph"],
+                dynamic=compile_args["dynamic"],
+                backend=compile_args["backend"],
+                mode=compile_args["mode"],
+            )
 
         return (vae,)
-
 
 
 class HyVideoTorchCompileSettings:
@@ -565,27 +889,76 @@ class HyVideoTorchCompileSettings:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "backend": (["inductor","cudagraphs"], {"default": "inductor"}),
-                "fullgraph": ("BOOLEAN", {"default": False, "tooltip": "Enable full graph mode"}),
-                "mode": (["default", "max-autotune", "max-autotune-no-cudagraphs", "reduce-overhead"], {"default": "default"}),
-                "dynamic": ("BOOLEAN", {"default": False, "tooltip": "Enable dynamic mode"}),
-                "dynamo_cache_size_limit": ("INT", {"default": 64, "min": 0, "max": 1024, "step": 1, "tooltip": "torch._dynamo.config.cache_size_limit"}),
-                "compile_single_blocks": ("BOOLEAN", {"default": True, "tooltip": "Compile single blocks"}),
-                "compile_double_blocks": ("BOOLEAN", {"default": True, "tooltip": "Compile double blocks"}),
-                "compile_txt_in": ("BOOLEAN", {"default": False, "tooltip": "Compile txt_in layers"}),
-                "compile_vector_in": ("BOOLEAN", {"default": False, "tooltip": "Compile vector_in layers"}),
-                "compile_final_layer": ("BOOLEAN", {"default": False, "tooltip": "Compile final layer"}),
-
+                "backend": (["inductor", "cudagraphs"], {"default": "inductor"}),
+                "fullgraph": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Enable full graph mode"},
+                ),
+                "mode": (
+                    [
+                        "default",
+                        "max-autotune",
+                        "max-autotune-no-cudagraphs",
+                        "reduce-overhead",
+                    ],
+                    {"default": "default"},
+                ),
+                "dynamic": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Enable dynamic mode"},
+                ),
+                "dynamo_cache_size_limit": (
+                    "INT",
+                    {
+                        "default": 64,
+                        "min": 0,
+                        "max": 1024,
+                        "step": 1,
+                        "tooltip": "torch._dynamo.config.cache_size_limit",
+                    },
+                ),
+                "compile_single_blocks": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Compile single blocks"},
+                ),
+                "compile_double_blocks": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Compile double blocks"},
+                ),
+                "compile_txt_in": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Compile txt_in layers"},
+                ),
+                "compile_vector_in": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Compile vector_in layers"},
+                ),
+                "compile_final_layer": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Compile final layer"},
+                ),
             },
         }
+
     RETURN_TYPES = ("COMPILEARGS",)
     RETURN_NAMES = ("torch_compile_args",)
     FUNCTION = "loadmodel"
     CATEGORY = "HunyuanVideoWrapper"
     DESCRIPTION = "torch.compile settings, when connected to the model loader, torch.compile of the selected layers is attempted. Requires Triton and torch 2.5.0 is recommended"
 
-    def loadmodel(self, backend, fullgraph, mode, dynamic, dynamo_cache_size_limit, compile_single_blocks, compile_double_blocks, compile_txt_in, compile_vector_in, compile_final_layer):
-
+    def loadmodel(
+        self,
+        backend,
+        fullgraph,
+        mode,
+        dynamic,
+        dynamo_cache_size_limit,
+        compile_single_blocks,
+        compile_double_blocks,
+        compile_txt_in,
+        compile_vector_in,
+        compile_final_layer,
+    ):
         compile_args = {
             "backend": backend,
             "fullgraph": fullgraph,
@@ -596,38 +969,72 @@ class HyVideoTorchCompileSettings:
             "compile_double_blocks": compile_double_blocks,
             "compile_txt_in": compile_txt_in,
             "compile_vector_in": compile_vector_in,
-            "compile_final_layer": compile_final_layer
+            "compile_final_layer": compile_final_layer,
         }
 
-        return (compile_args, )
+        return (compile_args,)
 
-#region TextEncode
+
+# region TextEncode
+
 
 class DownloadAndLoadHyVideoTextEncoder:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "llm_model": (["Kijai/llava-llama-3-8b-text-encoder-tokenizer","xtuner/llava-llama-3-8b-v1_1-transformers"],),
-                "clip_model": (["disabled","openai/clip-vit-large-patch14",],),
-                 "precision": (["fp16", "fp32", "bf16"],
-                    {"default": "bf16"}
+                "llm_model": (
+                    [
+                        "Kijai/llava-llama-3-8b-text-encoder-tokenizer",
+                        "xtuner/llava-llama-3-8b-v1_1-transformers",
+                    ],
                 ),
+                "clip_model": (
+                    [
+                        "disabled",
+                        "openai/clip-vit-large-patch14",
+                    ],
+                ),
+                "precision": (["fp16", "fp32", "bf16"], {"default": "bf16"}),
             },
             "optional": {
                 "apply_final_norm": ("BOOLEAN", {"default": False}),
                 "hidden_state_skip_layer": ("INT", {"default": 2}),
-                "quantization": (['disabled', 'bnb_nf4', "fp8_e4m3fn"], {"default": 'disabled'}),
-            }
+                "quantization": (
+                    ["disabled", "bnb_nf4", "fp8_e4m3fn"],
+                    {"default": "disabled"},
+                ),
+                # Note: Changing max_context_length is experimental and may cause instability or higher memory use
+                # max_context_length = 8192 is based on: https://huggingface.co/xtuner/llava-llama-3-8b-v1_1-transformers/blob/main/config.json
+                "max_context_length": (
+                    "INT",
+                    {
+                        "default": 256,  # HunyuanVideo default is 256
+                        "min": 1,
+                        "max": 8192,  # Max context length for the LLM
+                        "step": 1,
+                        "tooltip": "The maximum context length / max tokens for the LLM. Default is 256. Changing this is experimental and may cause instability in generation and performance, higher memory usage, or system crashes.",
+                    },
+                ),
+            },
         }
 
     RETURN_TYPES = ("HYVIDTEXTENCODER",)
-    RETURN_NAMES = ("hyvid_text_encoder", )
+    RETURN_NAMES = ("hyvid_text_encoder",)
     FUNCTION = "loadmodel"
     CATEGORY = "HunyuanVideoWrapper"
     DESCRIPTION = "Loads Hunyuan text_encoder model from 'ComfyUI/models/LLM'"
 
-    def loadmodel(self, llm_model, clip_model, precision,  apply_final_norm=False, hidden_state_skip_layer=2, quantization="disabled"):
+    def loadmodel(
+        self,
+        llm_model,
+        clip_model,
+        precision,
+        apply_final_norm=False,
+        hidden_state_skip_layer=2,
+        quantization="disabled",
+        max_context_length=256,
+    ):
         lm_type_mapping = {
             "Kijai/llava-llama-3-8b-text-encoder-tokenizer": "llm",
             "xtuner/llava-llama-3-8b-v1_1-transformers": "vlm",
@@ -635,23 +1042,28 @@ class DownloadAndLoadHyVideoTextEncoder:
         lm_type = lm_type_mapping[llm_model]
         device = mm.get_torch_device()
         offload_device = mm.unet_offload_device()
-        dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[precision]
+        dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[
+            precision
+        ]
         quantization_config = None
         if quantization == "bnb_nf4":
             from transformers import BitsAndBytesConfig
 
             quantization_config = BitsAndBytesConfig(
-            load_in_4bit=True,
-            bnb_4bit_quant_type="nf4",
-            bnb_4bit_use_double_quant=True,
-            bnb_4bit_compute_dtype=torch.bfloat16
+                load_in_4bit=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_compute_dtype=torch.bfloat16,
             )
-            
+
         if clip_model != "disabled":
-            clip_model_path = os.path.join(folder_paths.models_dir, "clip", "clip-vit-large-patch14")
+            clip_model_path = os.path.join(
+                folder_paths.models_dir, "clip", "clip-vit-large-patch14"
+            )
             if not os.path.exists(clip_model_path):
                 log.info(f"Downloading clip model to: {clip_model_path}")
                 from huggingface_hub import snapshot_download
+
                 snapshot_download(
                     repo_id=clip_model,
                     ignore_patterns=["*.msgpack", "*.bin", "*.h5"],
@@ -660,31 +1072,44 @@ class DownloadAndLoadHyVideoTextEncoder:
                 )
 
             text_encoder_2 = TextEncoder(
-            text_encoder_path=clip_model_path,
-            text_encoder_type="clipL",
-            max_length=77,
-            text_encoder_precision=precision,
-            tokenizer_type="clipL",
-            logger=log,
-            device=device,
-        )
+                text_encoder_path=clip_model_path,
+                text_encoder_type="clipL",
+                max_length=77,
+                text_encoder_precision=precision,
+                tokenizer_type="clipL",
+                logger=log,
+                device=device,
+            )
         else:
             text_encoder_2 = None
 
-        download_path = os.path.join(folder_paths.models_dir,"LLM")
+        download_path = os.path.join(folder_paths.models_dir, "LLM")
         base_path = os.path.join(download_path, (llm_model.split("/")[-1]))
         if not os.path.exists(base_path):
             log.info(f"Downloading model to: {base_path}")
             from huggingface_hub import snapshot_download
+
             snapshot_download(
                 repo_id=llm_model,
                 local_dir=base_path,
                 local_dir_use_symlinks=False,
             )
+
+        # Validation for max_context_length
+        if max_context_length <= PROMPT_TEMPLATE["dit-llm-encode-video"]["crop_start"]:
+            raise ValueError(
+                f"max_context_length ({max_context_length}) must be greater than crop_start ({PROMPT_TEMPLATE['dit-llm-encode-video']['crop_start']}) for the 'video' template."
+            )
+
+        # DEBUG: Log the max_length used by the TextEncoder
+        log.debug(
+            f"DownloadAndLoadHyVideoTextEncoder: Loading text encoder with max_context_length: {max_context_length}"
+        )
+
         text_encoder = TextEncoder(
             text_encoder_path=base_path,
             text_encoder_type=lm_type,
-            max_length=256,
+            max_length=max_context_length,  # max number of tokens / context for the LLM - default is 256
             text_encoder_precision=precision,
             tokenizer_type=lm_type,
             hidden_state_skip_layer=hidden_state_skip_layer,
@@ -692,18 +1117,27 @@ class DownloadAndLoadHyVideoTextEncoder:
             logger=log,
             device=device,
             dtype=dtype,
-            quantization_config=quantization_config
+            quantization_config=quantization_config,
         )
+        # DEBUG: Log the max_length used by the TextEncoder
+        log.debug(
+            f"[[DEBUG]] DownloadAndLoadHyVideoTextEncoder: TextEncoder initialized with max_length: {text_encoder.max_length}"
+        )
+
         if quantization == "fp8_e4m3fn":
             text_encoder.is_fp8 = True
             text_encoder.to(torch.float8_e4m3fn)
+
             def forward_hook(module):
                 def forward(hidden_states):
                     input_dtype = hidden_states.dtype
                     hidden_states = hidden_states.to(torch.float32)
                     variance = hidden_states.pow(2).mean(-1, keepdim=True)
-                    hidden_states = hidden_states * torch.rsqrt(variance + module.variance_epsilon)
+                    hidden_states = hidden_states * torch.rsqrt(
+                        variance + module.variance_epsilon
+                    )
                     return module.weight.to(input_dtype) * hidden_states.to(input_dtype)
+
                 return forward
 
             for module in text_encoder.model.modules():
@@ -721,16 +1155,32 @@ class DownloadAndLoadHyVideoTextEncoder:
 
         return (hyvid_text_encoders,)
 
+
 class HyVideoCustomPromptTemplate:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {
-            "custom_prompt_template": ("STRING", {"default": f"{PROMPT_TEMPLATE['dit-llm-encode-video']['template']}", "multiline": True}),
-            "crop_start": ("INT", {"default": PROMPT_TEMPLATE['dit-llm-encode-video']["crop_start"], "tooltip": "To cropt the system prompt"}),
+        return {
+            "required": {
+                "custom_prompt_template": (
+                    "STRING",
+                    {
+                        "default": f"{PROMPT_TEMPLATE['dit-llm-encode-video']['template']}",
+                        "multiline": True,
+                    },
+                ),
+                "crop_start": (
+                    "INT",
+                    {
+                        "default": PROMPT_TEMPLATE["dit-llm-encode-video"][
+                            "crop_start"
+                        ],
+                        "tooltip": "To cropt the system prompt",
+                    },
+                ),
             },
         }
 
-    RETURN_TYPES = ("PROMPT_TEMPLATE", )
+    RETURN_TYPES = ("PROMPT_TEMPLATE",)
     RETURN_NAMES = ("hyvid_prompt_template",)
     FUNCTION = "process"
     CATEGORY = "HunyuanVideoWrapper"
@@ -742,28 +1192,60 @@ class HyVideoCustomPromptTemplate:
         }
         return (prompt_template_dict,)
 
+
 class HyVideoTextEncode:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {
-            "text_encoders": ("HYVIDTEXTENCODER",),
-            "prompt": ("STRING", {"default": "", "multiline": True} ),
+        return {
+            "required": {
+                "text_encoders": ("HYVIDTEXTENCODER",),
+                "prompt": ("STRING", {"default": "", "multiline": True}),
             },
             "optional": {
                 "force_offload": ("BOOLEAN", {"default": True}),
-                "prompt_template": (["video", "image", "custom", "disabled"], {"default": "video", "tooltip": "Use the default prompt templates for the llm text encoder"}),
-                "custom_prompt_template": ("PROMPT_TEMPLATE", {"default": PROMPT_TEMPLATE["dit-llm-encode-video"], "multiline": True}),
-                "clip_l": ("CLIP", {"tooltip": "Use comfy clip model instead, in this case the text encoder loader's clip_l should be disabled"}),
-                "hyvid_cfg": ("HYVID_CFG", ),
-            }
+                "prompt_template": (
+                    ["video", "image", "custom", "disabled"],
+                    {
+                        "default": "video",
+                        "tooltip": "Use the default prompt templates for the llm text encoder",
+                    },
+                ),
+                "custom_prompt_template": (
+                    "PROMPT_TEMPLATE",
+                    {
+                        "default": PROMPT_TEMPLATE["dit-llm-encode-video"],
+                        "multiline": True,
+                    },
+                ),
+                "clip_l": (
+                    "CLIP",
+                    {
+                        "tooltip": "Use comfy clip model instead, in this case the text encoder loader's clip_l should be disabled"
+                    },
+                ),
+                "hyvid_cfg": ("HYVID_CFG",),
+            },
         }
 
-    RETURN_TYPES = ("HYVIDEMBEDS", )
+    RETURN_TYPES = ("HYVIDEMBEDS",)
     RETURN_NAMES = ("hyvid_embeds",)
     FUNCTION = "process"
     CATEGORY = "HunyuanVideoWrapper"
 
-    def process(self, text_encoders, prompt, force_offload=True, prompt_template="video", custom_prompt_template=None, clip_l=None, image_token_selection_expr="::4", hyvid_cfg=None, image1=None, image2=None, clip_text_override=None):
+    def process(
+        self,
+        text_encoders,
+        prompt,
+        force_offload=True,
+        prompt_template="video",
+        custom_prompt_template=None,
+        clip_l=None,
+        image_token_selection_expr="::4",
+        hyvid_cfg=None,
+        image1=None,
+        image2=None,
+        clip_text_override=None,
+    ):
         if clip_text_override is not None and len(clip_text_override) == 0:
             clip_text_override = None
         device = mm.text_encoder_device()
@@ -799,27 +1281,71 @@ class HyVideoTextEncode:
                 "`prompt_template['template']` must contain a placeholder `{}` for the input text, "
                 f"got {prompt_template_dict['template']}"
             )
+            # --- Apply and debug print the template ---
+            prompt_with_template = text_encoder_1.apply_text_to_template(
+                prompt, prompt_template_dict["template"]
+            )
+            log.debug(
+                f"HyVideoTextEncode: Prompt with template: {prompt_with_template}"
+            )
+
+            # --- Debug: Check for truncation and log token count ---
+            prompt_tokens = text_encoder_1.tokenizer(
+                prompt_with_template, return_length=True, return_tensors="pt"
+            )
+            token_count = prompt_tokens["length"][0].item()
+            if token_count > text_encoder_1.max_length:
+                log.info(
+                    f"HyVideoTextEncode: Prompt with template is {token_count} tokens long, which is longer than max_context_length ({text_encoder_1.max_length}). It will be truncated."
+                )
         else:
             prompt_template_dict = None
+            prompt_with_template = prompt  # No template applied
 
-        def encode_prompt(self, prompt, negative_prompt, text_encoder, image_token_selection_expr="::4", image1=None, image2=None, clip_text_override=None):
+        def encode_prompt(
+            self,
+            prompt,
+            negative_prompt,
+            text_encoder,
+            image_token_selection_expr="::4",
+            image1=None,
+            image2=None,
+            clip_text_override=None,
+        ):
             batch_size = 1
             num_videos_per_prompt = 1
 
-            text_inputs = text_encoder.text2tokens(prompt, 
-                                                   prompt_template=prompt_template_dict,
-                                                   image1=image1,
-                                                   image2=image2,
-                                                   clip_text_override=clip_text_override)
-            prompt_outputs = text_encoder.encode(text_inputs, 
-                                                 prompt_template=prompt_template_dict, 
-                                                 image_token_selection_expr=image_token_selection_expr, 
-                                                 device=device
-                                                 )
+            text_inputs = text_encoder.text2tokens(
+                prompt,
+                prompt_template=prompt_template_dict,
+                image1=image1,
+                image2=image2,
+                clip_text_override=clip_text_override,
+            )
+            # --- Debug print the token IDs ---
+            text_inputs = text_encoder.text2tokens(
+                prompt,
+                prompt_template=prompt_template_dict,
+                image1=image1,
+                image2=image2,
+                clip_text_override=clip_text_override,
+            )
+            log.debug(
+                f"HyVideoTextEncode.encode_prompt: Token IDs: {text_inputs['input_ids']}"
+            )
+
+            prompt_outputs = text_encoder.encode(
+                text_inputs,
+                prompt_template=prompt_template_dict,
+                image_token_selection_expr=image_token_selection_expr,
+                device=device,
+            )
             prompt_embeds = prompt_outputs.hidden_state
 
             attention_mask = prompt_outputs.attention_mask
-            log.info(f"{text_encoder.text_encoder_type} prompt attention_mask shape: {attention_mask.shape}, masked tokens: {attention_mask[0].sum().item()}")
+            log.debug(
+                f"{text_encoder.text_encoder_type} prompt attention_mask shape: {attention_mask.shape}, masked tokens: {attention_mask[0].sum().item()}"
+            )
             if attention_mask is not None:
                 attention_mask = attention_mask.to(device)
                 bs_embed, seq_len = attention_mask.shape
@@ -852,7 +1378,9 @@ class HyVideoTextEncode:
                     uncond_tokens = negative_prompt
 
                 # max_length = prompt_embeds.shape[1]
-                uncond_input = text_encoder.text2tokens(uncond_tokens, prompt_template=prompt_template_dict)
+                uncond_input = text_encoder.text2tokens(
+                    uncond_tokens, prompt_template=prompt_template_dict
+                )
 
                 negative_prompt_outputs = text_encoder.encode(
                     uncond_input, prompt_template=prompt_template_dict, device=device
@@ -879,34 +1407,65 @@ class HyVideoTextEncode:
                 attention_mask,
                 negative_attention_mask,
             )
+
         text_encoder_1.to(device)
-        with torch.autocast(device_type=mm.get_autocast_device(device), dtype=text_encoder_1.dtype, enabled=text_encoder_1.is_fp8):
-            prompt_embeds, negative_prompt_embeds, attention_mask, negative_attention_mask = encode_prompt(self,
-                                                                                                            prompt,
-                                                                                                            negative_prompt, 
-                                                                                                            text_encoder_1, 
-                                                                                                            image_token_selection_expr=image_token_selection_expr,
-                                                                                                            image1=image1,
-                                                                                                            image2=image2)
+        with torch.autocast(
+            device_type=mm.get_autocast_device(device),
+            dtype=text_encoder_1.dtype,
+            enabled=text_encoder_1.is_fp8,
+        ):
+            (
+                prompt_embeds,
+                negative_prompt_embeds,
+                attention_mask,
+                negative_attention_mask,
+            ) = encode_prompt(
+                self,
+                prompt,
+                negative_prompt,
+                text_encoder_1,
+                image_token_selection_expr=image_token_selection_expr,
+                image1=image1,
+                image2=image2,
+            )
         if force_offload:
             text_encoder_1.to(offload_device)
             mm.soft_empty_cache()
 
         if text_encoder_2 is not None:
             text_encoder_2.to(device)
-            prompt_embeds_2, negative_prompt_embeds_2, attention_mask_2, negative_attention_mask_2 = encode_prompt(self, prompt, negative_prompt, text_encoder_2, clip_text_override=clip_text_override)
+            (
+                prompt_embeds_2,
+                negative_prompt_embeds_2,
+                attention_mask_2,
+                negative_attention_mask_2,
+            ) = encode_prompt(
+                self,
+                prompt_with_template,  # Use the prompt_with_template here
+                # prompt,
+                negative_prompt,
+                text_encoder_2,
+                clip_text_override=clip_text_override,
+            )
             if force_offload:
                 text_encoder_2.to(offload_device)
                 mm.soft_empty_cache()
         elif clip_l is not None:
             clip_l.cond_stage_model.to(device)
-            tokens = clip_l.tokenize(prompt if clip_text_override is None else clip_text_override, return_word_ids=True)
-            prompt_embeds_2 = clip_l.encode_from_tokens(tokens, return_pooled=True, return_dict=False)[1]
+            tokens = clip_l.tokenize(
+                prompt if clip_text_override is None else clip_text_override,
+                return_word_ids=True,
+            )
+            prompt_embeds_2 = clip_l.encode_from_tokens(
+                tokens, return_pooled=True, return_dict=False
+            )[1]
             prompt_embeds_2 = prompt_embeds_2.to(device=device)
 
             if negative_prompt is not None:
                 tokens = clip_l.tokenize(negative_prompt, return_word_ids=True)
-                negative_prompt_embeds_2 = clip_l.encode_from_tokens(tokens, return_pooled=True, return_dict=False)[1]
+                negative_prompt_embeds_2 = clip_l.encode_from_tokens(
+                    tokens, return_pooled=True, return_dict=False
+                )[1]
                 negative_prompt_embeds_2 = negative_prompt_embeds_2.to(device=device)
             else:
                 negative_prompt_embeds_2 = None
@@ -921,60 +1480,133 @@ class HyVideoTextEncode:
             attention_mask_2 = None
             negative_attention_mask_2 = None
 
+        # Debug prompts
+        log.debug(f"HyVideoTextEncode: Prompt embeds shape: {prompt_embeds.shape}")
+        log.debug(
+            f"HyVideoTextEncode: Negative prompt embeds shape: {negative_prompt_embeds.shape if negative_prompt_embeds is not None else None}"
+        )
+        log.debug(
+            f"HyVideoTextEncode: Attention mask shape: {attention_mask.shape if attention_mask is not None else None}"
+        )
+        log.debug(
+            f"HyVideoTextEncode: Negative attention mask shape: {negative_attention_mask.shape if negative_attention_mask is not None else None}"
+        )
+
         prompt_embeds_dict = {
-                "prompt_embeds": prompt_embeds,
-                "negative_prompt_embeds": negative_prompt_embeds,
-                "attention_mask": attention_mask,
-                "negative_attention_mask": negative_attention_mask,
-                "prompt_embeds_2": prompt_embeds_2,
-                "negative_prompt_embeds_2": negative_prompt_embeds_2,
-                "attention_mask_2": attention_mask_2,
-                "negative_attention_mask_2": negative_attention_mask_2,
-                "cfg": torch.tensor(hyvid_cfg["cfg"]) if hyvid_cfg is not None else None,
-                "start_percent": torch.tensor(hyvid_cfg["start_percent"]) if hyvid_cfg is not None else None,
-                "end_percent": torch.tensor(hyvid_cfg["end_percent"]) if hyvid_cfg is not None else None,
-            }
+            "prompt_embeds": prompt_embeds,
+            "negative_prompt_embeds": negative_prompt_embeds,
+            "attention_mask": attention_mask,
+            "negative_attention_mask": negative_attention_mask,
+            "prompt_embeds_2": prompt_embeds_2,
+            "negative_prompt_embeds_2": negative_prompt_embeds_2,
+            "attention_mask_2": attention_mask_2,
+            "negative_attention_mask_2": negative_attention_mask_2,
+            "cfg": torch.tensor(hyvid_cfg["cfg"]) if hyvid_cfg is not None else None,
+            "start_percent": torch.tensor(hyvid_cfg["start_percent"])
+            if hyvid_cfg is not None
+            else None,
+            "end_percent": torch.tensor(hyvid_cfg["end_percent"])
+            if hyvid_cfg is not None
+            else None,
+        }
         return (prompt_embeds_dict,)
+
 
 class HyVideoTextImageEncode(HyVideoTextEncode):
     # Experimental Image Prompt to Video (IP2V) via VLM implementation by @Dango233
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {
-            "text_encoders": ("HYVIDTEXTENCODER",),
-            "prompt": ("STRING", {"default": "", "multiline": True} ),
-            "image_token_selection_expr": ("STRING", {"default": "::4", "multiline": False} ),
+        return {
+            "required": {
+                "text_encoders": ("HYVIDTEXTENCODER",),
+                "prompt": ("STRING", {"default": "", "multiline": True}),
+                "image_token_selection_expr": (
+                    "STRING",
+                    {"default": "::4", "multiline": False},
+                ),
             },
             "optional": {
                 "force_offload": ("BOOLEAN", {"default": True}),
-                "prompt_template": (["video", "image", "custom", "disabled"], {"default": "video", "tooltip": "Use the default prompt templates for the llm text encoder"}),
-                "custom_prompt_template": ("PROMPT_TEMPLATE", {"default": PROMPT_TEMPLATE["dit-llm-encode-video"], "multiline": True}),
-                "clip_l": ("CLIP", {"tooltip": "Use comfy clip model instead, in this case the text encoder loader's clip_l should be disabled"}),
+                "prompt_template": (
+                    ["video", "image", "custom", "disabled"],
+                    {
+                        "default": "video",
+                        "tooltip": "Use the default prompt templates for the llm text encoder",
+                    },
+                ),
+                "custom_prompt_template": (
+                    "PROMPT_TEMPLATE",
+                    {
+                        "default": PROMPT_TEMPLATE["dit-llm-encode-video"],
+                        "multiline": True,
+                    },
+                ),
+                "clip_l": (
+                    "CLIP",
+                    {
+                        "tooltip": "Use comfy clip model instead, in this case the text encoder loader's clip_l should be disabled"
+                    },
+                ),
                 "image1": ("IMAGE", {"default": None}),
                 "image2": ("IMAGE", {"default": None}),
-                "clip_text_override": ("STRING", {"default": "", "multiline": True} ),
-                "hyvid_cfg": ("HYVID_CFG", ),
-            }
+                "clip_text_override": ("STRING", {"default": "", "multiline": True}),
+                "hyvid_cfg": ("HYVID_CFG",),
+            },
         }
 
-    RETURN_TYPES = ("HYVIDEMBEDS", )
+    RETURN_TYPES = ("HYVIDEMBEDS",)
     RETURN_NAMES = ("hyvid_embeds",)
     FUNCTION = "process"
     CATEGORY = "HunyuanVideoWrapper"
 
-# region CFG    
+
+# region CFG
 class HyVideoCFG:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {
-            "negative_prompt": ("STRING", {"default": "Aerial view, aerial view, overexposed, low quality, deformation, a poor composition, bad hands, bad teeth, bad eyes, bad limbs, distortion", "multiline": True} ),
-            "cfg": ("FLOAT", {"default": 2.0, "min": 0.0, "max": 100.0, "step": 0.01, "tooltip": "guidance scale"} ),
-            "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 100.0, "step": 0.01, "tooltip": "Start percentage of the steps to apply CFG, rest of the steps use guidance_embeds"} ),
-            "end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 100.0, "step": 0.01, "tooltip": "End percentage of the steps to apply CFG, rest of the steps use guidance_embeds"} ),
+        return {
+            "required": {
+                "negative_prompt": (
+                    "STRING",
+                    {
+                        "default": "Aerial view, aerial view, overexposed, low quality, deformation, a poor composition, bad hands, bad teeth, bad eyes, bad limbs, distortion",
+                        "multiline": True,
+                    },
+                ),
+                "cfg": (
+                    "FLOAT",
+                    {
+                        "default": 2.0,
+                        "min": 0.0,
+                        "max": 100.0,
+                        "step": 0.01,
+                        "tooltip": "guidance scale",
+                    },
+                ),
+                "start_percent": (
+                    "FLOAT",
+                    {
+                        "default": 0.0,
+                        "min": 0.0,
+                        "max": 100.0,
+                        "step": 0.01,
+                        "tooltip": "Start percentage of the steps to apply CFG, rest of the steps use guidance_embeds",
+                    },
+                ),
+                "end_percent": (
+                    "FLOAT",
+                    {
+                        "default": 1.0,
+                        "min": 0.0,
+                        "max": 100.0,
+                        "step": 0.01,
+                        "tooltip": "End percentage of the steps to apply CFG, rest of the steps use guidance_embeds",
+                    },
+                ),
             },
         }
 
-    RETURN_TYPES = ("HYVID_CFG", )
+    RETURN_TYPES = ("HYVID_CFG",)
     RETURN_NAMES = ("hyvid_cfg",)
     FUNCTION = "process"
     CATEGORY = "HunyuanVideoWrapper"
@@ -987,32 +1619,37 @@ class HyVideoCFG:
             "start_percent": start_percent,
             "end_percent": end_percent,
         }
-        
+
         return (cfg_dict,)
 
-#region embeds
+
+# region embeds
 class HyVideoTextEmbedsSave:
     def __init__(self):
         self.output_dir = folder_paths.get_output_directory()
+
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {
-            "hyvid_embeds": ("HYVIDEMBEDS",),
-            "filename_prefix": ("STRING", {"default": "hyvid_embeds/hyvid_embed"}),
+        return {
+            "required": {
+                "hyvid_embeds": ("HYVIDEMBEDS",),
+                "filename_prefix": ("STRING", {"default": "hyvid_embeds/hyvid_embed"}),
             },
             "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"},
         }
 
-    RETURN_TYPES = ("STRING", )
+    RETURN_TYPES = ("STRING",)
     RETURN_NAMES = ("output_path",)
     FUNCTION = "save"
     CATEGORY = "HunyuanVideoWrapper"
     DESCRIPTION = "Save the text embeds"
 
-
     def save(self, hyvid_embeds, prompt, filename_prefix, extra_pnginfo=None):
         from comfy.cli_args import args
-        full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir)
+
+        full_output_folder, filename, counter, subfolder, filename_prefix = (
+            folder_paths.get_save_image_path(filename_prefix, self.output_dir)
+        )
         file = f"{filename}_{counter:05}_.safetensors"
         file = os.path.join(full_output_folder, file)
 
@@ -1030,22 +1667,29 @@ class HyVideoTextEmbedsSave:
             if extra_pnginfo is not None:
                 for x in extra_pnginfo:
                     metadata[x] = json.dumps(extra_pnginfo[x])
-        
+
         save_torch_file(tensors_to_save, file, metadata=metadata)
-        
+
         return (file,)
+
 
 class HyVideoTextEmbedsLoad:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {"embeds": (folder_paths.get_filename_list("hyvid_embeds"), {"tooltip": "The saved embeds to load from output/hyvid_embeds."})}}
+        return {
+            "required": {
+                "embeds": (
+                    folder_paths.get_filename_list("hyvid_embeds"),
+                    {"tooltip": "The saved embeds to load from output/hyvid_embeds."},
+                )
+            }
+        }
 
-    RETURN_TYPES = ("HYVIDEMBEDS", )
+    RETURN_TYPES = ("HYVIDEMBEDS",)
     RETURN_NAMES = ("hyvid_embeds",)
     FUNCTION = "load"
     CATEGORY = "HunyuanVideoWrapper"
     DESCTIPTION = "Load the saved text embeds"
-
 
     def load(self, embeds):
         embed_path = folder_paths.get_full_path_or_raise("hyvid_embeds", embeds)
@@ -1053,78 +1697,143 @@ class HyVideoTextEmbedsLoad:
         # Reconstruct original dictionary with None for missing keys
         prompt_embeds_dict = {
             "prompt_embeds": loaded_tensors.get("prompt_embeds", None),
-            "negative_prompt_embeds": loaded_tensors.get("negative_prompt_embeds", None),
+            "negative_prompt_embeds": loaded_tensors.get(
+                "negative_prompt_embeds", None
+            ),
             "attention_mask": loaded_tensors.get("attention_mask", None),
-            "negative_attention_mask": loaded_tensors.get("negative_attention_mask", None),
+            "negative_attention_mask": loaded_tensors.get(
+                "negative_attention_mask", None
+            ),
             "prompt_embeds_2": loaded_tensors.get("prompt_embeds_2", None),
-            "negative_prompt_embeds_2": loaded_tensors.get("negative_prompt_embeds_2", None),
+            "negative_prompt_embeds_2": loaded_tensors.get(
+                "negative_prompt_embeds_2", None
+            ),
             "attention_mask_2": loaded_tensors.get("attention_mask_2", None),
-            "negative_attention_mask_2": loaded_tensors.get("negative_attention_mask_2", None),
+            "negative_attention_mask_2": loaded_tensors.get(
+                "negative_attention_mask_2", None
+            ),
             "cfg": loaded_tensors.get("cfg", None),
             "start_percent": loaded_tensors.get("start_percent", None),
             "end_percent": loaded_tensors.get("end_percent", None),
         }
-        
+
         return (prompt_embeds_dict,)
-    
+
+
 class HyVideoContextOptions:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {
-            "context_schedule": (["uniform_standard", "uniform_looped", "static_standard"],),
-            "context_frames": ("INT", {"default": 65, "min": 2, "max": 1000, "step": 1, "tooltip": "Number of pixel frames in the context, NOTE: the latent space has 4 frames in 1"} ),
-            "context_stride": ("INT", {"default": 4, "min": 4, "max": 100, "step": 1, "tooltip": "Context stride as pixel frames, NOTE: the latent space has 4 frames in 1"} ),
-            "context_overlap": ("INT", {"default": 4, "min": 4, "max": 100, "step": 1, "tooltip": "Context overlap as pixel frames, NOTE: the latent space has 4 frames in 1"} ),
-            "freenoise": ("BOOLEAN", {"default": True, "tooltip": "Shuffle the noise"}),
+        return {
+            "required": {
+                "context_schedule": (
+                    ["uniform_standard", "uniform_looped", "static_standard"],
+                ),
+                "context_frames": (
+                    "INT",
+                    {
+                        "default": 65,
+                        "min": 2,
+                        "max": 1000,
+                        "step": 1,
+                        "tooltip": "Number of pixel frames in the context, NOTE: the latent space has 4 frames in 1",
+                    },
+                ),
+                "context_stride": (
+                    "INT",
+                    {
+                        "default": 4,
+                        "min": 4,
+                        "max": 100,
+                        "step": 1,
+                        "tooltip": "Context stride as pixel frames, NOTE: the latent space has 4 frames in 1",
+                    },
+                ),
+                "context_overlap": (
+                    "INT",
+                    {
+                        "default": 4,
+                        "min": 4,
+                        "max": 100,
+                        "step": 1,
+                        "tooltip": "Context overlap as pixel frames, NOTE: the latent space has 4 frames in 1",
+                    },
+                ),
+                "freenoise": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Shuffle the noise"},
+                ),
             }
         }
 
-    RETURN_TYPES = ("HYVIDCONTEXT", )
+    RETURN_TYPES = ("HYVIDCONTEXT",)
     RETURN_NAMES = ("context_options",)
     FUNCTION = "process"
     CATEGORY = "HunyuanVideoWrapper"
     DESCRIPTION = "Context options for HunyuanVideo, allows splitting the video into context windows and attemps blending them for longer generations than the model and memory otherwise would allow."
 
-    def process(self, context_schedule, context_frames, context_stride, context_overlap, freenoise):
+    def process(
+        self,
+        context_schedule,
+        context_frames,
+        context_stride,
+        context_overlap,
+        freenoise,
+    ):
         context_options = {
-            "context_schedule":context_schedule,
-            "context_frames":context_frames,
-            "context_stride":context_stride,
-            "context_overlap":context_overlap,
-            "freenoise":freenoise
+            "context_schedule": context_schedule,
+            "context_frames": context_frames,
+            "context_stride": context_stride,
+            "context_overlap": context_overlap,
+            "freenoise": freenoise,
         }
 
         return (context_options,)
-#region Sampler
+
+
+# region Sampler
 class HyVideoSampler:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
                 "model": ("HYVIDEOMODEL",),
-                "hyvid_embeds": ("HYVIDEMBEDS", ),
+                "hyvid_embeds": ("HYVIDEMBEDS",),
                 "width": ("INT", {"default": 512, "min": 64, "max": 4096, "step": 16}),
                 "height": ("INT", {"default": 512, "min": 64, "max": 4096, "step": 16}),
-                "num_frames": ("INT", {"default": 49, "min": 1, "max": 1024, "step": 4}),
+                "num_frames": (
+                    "INT",
+                    {"default": 49, "min": 1, "max": 1024, "step": 4},
+                ),
                 "steps": ("INT", {"default": 30, "min": 1}),
-                "embedded_guidance_scale": ("FLOAT", {"default": 6.0, "min": 0.0, "max": 30.0, "step": 0.01}),
-                "flow_shift": ("FLOAT", {"default": 9.0, "min": 0.0, "max": 1000.0, "step": 0.01}),
-                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                "embedded_guidance_scale": (
+                    "FLOAT",
+                    {"default": 6.0, "min": 0.0, "max": 30.0, "step": 0.01},
+                ),
+                "flow_shift": (
+                    "FLOAT",
+                    {"default": 9.0, "min": 0.0, "max": 1000.0, "step": 0.01},
+                ),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFFFFFFFFFFFF}),
                 "force_offload": ("BOOLEAN", {"default": True}),
-
             },
             "optional": {
-                "samples": ("LATENT", {"tooltip": "init Latents to use for video2video process"} ),
-                "denoise_strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "stg_args": ("STGARGS", ),
-                "context_options": ("HYVIDCONTEXT", ),
-                "feta_args": ("FETAARGS", ),
-                "teacache_args": ("TEACACHEARGS", ),
-                "scheduler": (available_schedulers,
-                    {
-                        "default": 'FlowMatchDiscreteScheduler'
-                    }),
-            }
+                "samples": (
+                    "LATENT",
+                    {"tooltip": "init Latents to use for video2video process"},
+                ),
+                "denoise_strength": (
+                    "FLOAT",
+                    {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01},
+                ),
+                "stg_args": ("STGARGS",),
+                "context_options": ("HYVIDCONTEXT",),
+                "feta_args": ("FETAARGS",),
+                "teacache_args": ("TEACACHEARGS",),
+                "scheduler": (
+                    available_schedulers,
+                    {"default": "FlowMatchDiscreteScheduler"},
+                ),
+            },
         }
 
     RETURN_TYPES = ("LATENT",)
@@ -1132,8 +1841,26 @@ class HyVideoSampler:
     FUNCTION = "process"
     CATEGORY = "HunyuanVideoWrapper"
 
-    def process(self, model, hyvid_embeds, flow_shift, steps, embedded_guidance_scale, seed, width, height, num_frames, 
-                samples=None, denoise_strength=1.0, force_offload=True, stg_args=None, context_options=None, feta_args=None, teacache_args=None, scheduler=None):
+    def process(
+        self,
+        model,
+        hyvid_embeds,
+        flow_shift,
+        steps,
+        embedded_guidance_scale,
+        seed,
+        width,
+        height,
+        num_frames,
+        samples=None,
+        denoise_strength=1.0,
+        force_offload=True,
+        stg_args=None,
+        context_options=None,
+        feta_args=None,
+        teacache_args=None,
+        scheduler=None,
+    ):
         model = model.model
 
         device = mm.get_torch_device()
@@ -1141,13 +1868,13 @@ class HyVideoSampler:
         dtype = model["dtype"]
         transformer = model["pipe"].transformer
 
-        #handle STG
+        # handle STG
         if stg_args is not None:
             if stg_args["stg_mode"] == "STG-A" and transformer.attention_mode != "sdpa":
                 raise ValueError(
                     f"STG-A requires attention_mode to be 'sdpa', but got {transformer.attention_mode}."
-            )
-        #handle CFG
+                )
+        # handle CFG
         if hyvid_embeds.get("cfg") is not None:
             cfg = float(hyvid_embeds.get("cfg", 1.0))
             cfg_start_percent = float(hyvid_embeds.get("start_percent", 0.0))
@@ -1184,8 +1911,8 @@ class HyVideoSampler:
             scheduler_config["algorithm_type"] = "data_prediction"
         else:
             scheduler_config.pop("algorithm_type", None)
-        #model["scheduler_config"]["use_beta_flow_sigmas"] = True
-        
+        # model["scheduler_config"]["use_beta_flow_sigmas"] = True
+
         noise_scheduler = scheduler_mapping[scheduler].from_config(scheduler_config)
         model["pipe"].scheduler = noise_scheduler
 
@@ -1195,10 +1922,10 @@ class HyVideoSampler:
                     param.data = param.data.to(device)
 
             transformer.block_swap(
-                model["block_swap_args"]["double_blocks_to_swap"] - 1 ,
+                model["block_swap_args"]["double_blocks_to_swap"] - 1,
                 model["block_swap_args"]["single_blocks_to_swap"] - 1,
-                offload_txt_in = model["block_swap_args"]["offload_txt_in"],
-                offload_img_in = model["block_swap_args"]["offload_img_in"],
+                offload_txt_in=model["block_swap_args"]["offload_txt_in"],
+                offload_img_in=model["block_swap_args"]["offload_img_in"],
             )
         elif model["auto_cpu_offload"]:
             for name, param in transformer.named_parameters():
@@ -1210,10 +1937,12 @@ class HyVideoSampler:
         # Initialize TeaCache if enabled
         if teacache_args is not None:
             # Check if dimensions have changed since last run
-            if (not hasattr(transformer, 'last_dimensions') or
-                    transformer.last_dimensions != (height, width, num_frames) or
-                    not hasattr(transformer, 'last_frame_count') or
-                    transformer.last_frame_count != num_frames):
+            if (
+                not hasattr(transformer, "last_dimensions")
+                or transformer.last_dimensions != (height, width, num_frames)
+                or not hasattr(transformer, "last_frame_count")
+                or transformer.last_frame_count != num_frames
+            ):
                 # Reset TeaCache state on dimension change
                 transformer.cnt = 0
                 transformer.accumulated_rel_l1_distance = 0
@@ -1236,27 +1965,33 @@ class HyVideoSampler:
         except:
             pass
 
-        #for name, param in transformer.named_parameters():
+        # for name, param in transformer.named_parameters():
         #    print(name, param.data.device)
 
         out_latents = model["pipe"](
             num_inference_steps=steps,
-            height = target_height,
-            width = target_width,
-            video_length = num_frames,
+            height=target_height,
+            width=target_width,
+            video_length=num_frames,
             guidance_scale=cfg,
             cfg_start_percent=cfg_start_percent,
             cfg_end_percent=cfg_end_percent,
             embedded_guidance_scale=embedded_guidance_scale,
-            latents=samples["samples"] * VAE_SCALING_FACTOR if samples is not None else None,
+            latents=samples["samples"] * VAE_SCALING_FACTOR
+            if samples is not None
+            else None,
             denoise_strength=denoise_strength,
             prompt_embed_dict=hyvid_embeds,
             generator=generator,
             stg_mode=stg_args["stg_mode"] if stg_args is not None else None,
             stg_block_idx=stg_args["stg_block_idx"] if stg_args is not None else -1,
             stg_scale=stg_args["stg_scale"] if stg_args is not None else 0.0,
-            stg_start_percent=stg_args["stg_start_percent"] if stg_args is not None else 0.0,
-            stg_end_percent=stg_args["stg_end_percent"] if stg_args is not None else 1.0,
+            stg_start_percent=stg_args["stg_start_percent"]
+            if stg_args is not None
+            else 0.0,
+            stg_end_percent=stg_args["stg_end_percent"]
+            if stg_args is not None
+            else 1.0,
             context_options=context_options,
             feta_args=feta_args,
         )
@@ -1273,35 +2008,72 @@ class HyVideoSampler:
                 mm.soft_empty_cache()
                 gc.collect()
 
-        return ({
-            "samples": out_latents.cpu() / VAE_SCALING_FACTOR
-            },)
+        return ({"samples": out_latents.cpu() / VAE_SCALING_FACTOR},)
 
-#region VideoDecode
+
+# region VideoDecode
 class HyVideoDecode:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {
-                    "vae": ("VAE",),
-                    "samples": ("LATENT",),
-                    "enable_vae_tiling": ("BOOLEAN", {"default": True, "tooltip": "Drastically reduces memory use but may introduce seams"}),
-                    "temporal_tiling_sample_size": ("INT", {"default": 64, "min": 4, "max": 256, "tooltip": "Smaller values use less VRAM, model default is 64, any other value will cause stutter"}),
-                    "spatial_tile_sample_min_size": ("INT", {"default": 256, "min": 32, "max": 2048, "step": 32, "tooltip": "Spatial tile minimum size in pixels, smaller values use less VRAM, may introduce more seams"}),
-                    "auto_tile_size": ("BOOLEAN", {"default": True, "tooltip": "Automatically set tile size based on defaults, above settings are ignored"}),
+        return {
+            "required": {
+                "vae": ("VAE",),
+                "samples": ("LATENT",),
+                "enable_vae_tiling": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Drastically reduces memory use but may introduce seams",
                     },
-                }
+                ),
+                "temporal_tiling_sample_size": (
+                    "INT",
+                    {
+                        "default": 64,
+                        "min": 4,
+                        "max": 256,
+                        "tooltip": "Smaller values use less VRAM, model default is 64, any other value will cause stutter",
+                    },
+                ),
+                "spatial_tile_sample_min_size": (
+                    "INT",
+                    {
+                        "default": 256,
+                        "min": 32,
+                        "max": 2048,
+                        "step": 32,
+                        "tooltip": "Spatial tile minimum size in pixels, smaller values use less VRAM, may introduce more seams",
+                    },
+                ),
+                "auto_tile_size": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Automatically set tile size based on defaults, above settings are ignored",
+                    },
+                ),
+            },
+        }
 
     RETURN_TYPES = ("IMAGE",)
     RETURN_NAMES = ("images",)
     FUNCTION = "decode"
     CATEGORY = "HunyuanVideoWrapper"
 
-    def decode(self, vae, samples, enable_vae_tiling, temporal_tiling_sample_size, spatial_tile_sample_min_size, auto_tile_size):
+    def decode(
+        self,
+        vae,
+        samples,
+        enable_vae_tiling,
+        temporal_tiling_sample_size,
+        spatial_tile_sample_min_size,
+        auto_tile_size,
+    ):
         device = mm.get_torch_device()
         offload_device = mm.unet_offload_device()
         mm.soft_empty_cache()
         latents = samples["samples"]
-        generator = torch.Generator(device=torch.device("cpu"))#.manual_seed(seed)
+        generator = torch.Generator(device=torch.device("cpu"))  # .manual_seed(seed)
         vae.to(device)
         if not auto_tile_size:
             vae.tile_latent_min_tsize = temporal_tiling_sample_size // 4
@@ -1312,11 +2084,10 @@ class HyVideoDecode:
             else:
                 vae.t_tile_overlap_factor = 0.25
         else:
-            #defaults
+            # defaults
             vae.tile_latent_min_tsize = 16
             vae.tile_sample_min_size = 256
             vae.tile_latent_min_size = 32
-
 
         expand_temporal_dim = False
         if len(latents.shape) == 4:
@@ -1329,18 +2100,14 @@ class HyVideoDecode:
             raise ValueError(
                 f"Only support latents with shape (b, c, h, w) or (b, c, f, h, w), but got {latents.shape}."
             )
-        #latents = latents / vae.config.scaling_factor
+        # latents = latents / vae.config.scaling_factor
         latents = latents.to(vae.dtype).to(device)
 
         if enable_vae_tiling:
             vae.enable_tiling()
-            video = vae.decode(
-                latents, return_dict=False, generator=generator
-            )[0]
+            video = vae.decode(latents, return_dict=False, generator=generator)[0]
         else:
-            video = vae.decode(
-                latents, return_dict=False, generator=generator
-            )[0]
+            video = vae.decode(latents, return_dict=False, generator=generator)[0]
 
         if expand_temporal_dim or video.shape[2] == 1:
             video = video.squeeze(2)
@@ -1360,30 +2127,69 @@ class HyVideoDecode:
 
         return (out,)
 
-#region VideoEncode
+
+# region VideoEncode
 class HyVideoEncode:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {
-                    "vae": ("VAE",),
-                    "image": ("IMAGE",),
-                    "enable_vae_tiling": ("BOOLEAN", {"default": True, "tooltip": "Drastically reduces memory use but may introduce seams"}),
-                    "temporal_tiling_sample_size": ("INT", {"default": 64, "min": 4, "max": 256, "tooltip": "Smaller values use less VRAM, model default is 64, any other value will cause stutter"}),
-                    "spatial_tile_sample_min_size": ("INT", {"default": 256, "min": 32, "max": 2048, "step": 32, "tooltip": "Spatial tile minimum size in pixels, smaller values use less VRAM, may introduce more seams"}),
-                    "auto_tile_size": ("BOOLEAN", {"default": True, "tooltip": "Automatically set tile size based on defaults, above settings are ignored"}),
+        return {
+            "required": {
+                "vae": ("VAE",),
+                "image": ("IMAGE",),
+                "enable_vae_tiling": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Drastically reduces memory use but may introduce seams",
                     },
-                }
+                ),
+                "temporal_tiling_sample_size": (
+                    "INT",
+                    {
+                        "default": 64,
+                        "min": 4,
+                        "max": 256,
+                        "tooltip": "Smaller values use less VRAM, model default is 64, any other value will cause stutter",
+                    },
+                ),
+                "spatial_tile_sample_min_size": (
+                    "INT",
+                    {
+                        "default": 256,
+                        "min": 32,
+                        "max": 2048,
+                        "step": 32,
+                        "tooltip": "Spatial tile minimum size in pixels, smaller values use less VRAM, may introduce more seams",
+                    },
+                ),
+                "auto_tile_size": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Automatically set tile size based on defaults, above settings are ignored",
+                    },
+                ),
+            },
+        }
 
     RETURN_TYPES = ("LATENT",)
     RETURN_NAMES = ("samples",)
     FUNCTION = "encode"
     CATEGORY = "HunyuanVideoWrapper"
 
-    def encode(self, vae, image, enable_vae_tiling, temporal_tiling_sample_size, auto_tile_size, spatial_tile_sample_min_size):
+    def encode(
+        self,
+        vae,
+        image,
+        enable_vae_tiling,
+        temporal_tiling_sample_size,
+        auto_tile_size,
+        spatial_tile_sample_min_size,
+    ):
         device = mm.get_torch_device()
         offload_device = mm.unet_offload_device()
 
-        generator = torch.Generator(device=torch.device("cpu"))#.manual_seed(seed)
+        generator = torch.Generator(device=torch.device("cpu"))  # .manual_seed(seed)
         vae.to(device)
         if not auto_tile_size:
             vae.tile_latent_min_tsize = temporal_tiling_sample_size // 4
@@ -1394,21 +2200,27 @@ class HyVideoEncode:
             else:
                 vae.t_tile_overlap_factor = 0.25
         else:
-            #defaults
+            # defaults
             vae.tile_latent_min_tsize = 16
             vae.tile_sample_min_size = 256
             vae.tile_latent_min_size = 32
 
-        image = (image * 2.0 - 1.0).to(vae.dtype).to(device).unsqueeze(0).permute(0, 4, 1, 2, 3) # B, C, T, H, W
+        image = (
+            (image * 2.0 - 1.0)
+            .to(vae.dtype)
+            .to(device)
+            .unsqueeze(0)
+            .permute(0, 4, 1, 2, 3)
+        )  # B, C, T, H, W
         if enable_vae_tiling:
             vae.enable_tiling()
         latents = vae.encode(image).latent_dist.sample(generator)
-        #latents = latents * vae.config.scaling_factor
+        # latents = latents * vae.config.scaling_factor
         vae.to(offload_device)
-        print("encoded latents shape",latents.shape)
-
+        print("encoded latents shape", latents.shape)
 
         return ({"samples": latents},)
+
 
 class HyVideoLatentPreview:
     @classmethod
@@ -1416,17 +2228,38 @@ class HyVideoLatentPreview:
         return {
             "required": {
                 "samples": ("LATENT",),
-                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
-                 "min_val": ("FLOAT", {"default": -0.15, "min": -1.0, "max": 0.0, "step": 0.001}),
-                 "max_val": ("FLOAT", {"default": 0.15, "min": 0.0, "max": 1.0, "step": 0.001}),
-                 "r_bias": ("FLOAT", {"default": 0.0, "min": -1.0, "max": 1.0, "step": 0.001}),
-                 "g_bias": ("FLOAT", {"default": 0.0, "min": -1.0, "max": 1.0, "step": 0.001}),
-                 "b_bias": ("FLOAT", {"default": 0.0, "min": -1.0, "max": 1.0, "step": 0.001}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFFFFFFFFFFFF}),
+                "min_val": (
+                    "FLOAT",
+                    {"default": -0.15, "min": -1.0, "max": 0.0, "step": 0.001},
+                ),
+                "max_val": (
+                    "FLOAT",
+                    {"default": 0.15, "min": 0.0, "max": 1.0, "step": 0.001},
+                ),
+                "r_bias": (
+                    "FLOAT",
+                    {"default": 0.0, "min": -1.0, "max": 1.0, "step": 0.001},
+                ),
+                "g_bias": (
+                    "FLOAT",
+                    {"default": 0.0, "min": -1.0, "max": 1.0, "step": 0.001},
+                ),
+                "b_bias": (
+                    "FLOAT",
+                    {"default": 0.0, "min": -1.0, "max": 1.0, "step": 0.001},
+                ),
             },
         }
 
-    RETURN_TYPES = ("IMAGE", "STRING", )
-    RETURN_NAMES = ("images", "latent_rgb_factors",)
+    RETURN_TYPES = (
+        "IMAGE",
+        "STRING",
+    )
+    RETURN_NAMES = (
+        "images",
+        "latent_rgb_factors",
+    )
     FUNCTION = "sample"
     CATEGORY = "HunyuanVideoWrapper"
 
@@ -1435,35 +2268,42 @@ class HyVideoLatentPreview:
 
         latents = samples["samples"].clone()
         print("in sample", latents.shape)
-        #latent_rgb_factors =[[-0.02531045419704009, -0.00504800612542497, 0.13293717293982546], [-0.03421835830845858, 0.13996708548892614, -0.07081038680118075], [0.011091819063647063, -0.03372949685846012, -0.0698232210116172], [-0.06276524604742019, -0.09322986677909442, 0.01826383612148913], [0.021290659938126788, -0.07719530444034409, -0.08247812477766273], [0.04401102991215147, -0.0026401932105894754, -0.01410913586718443], [0.08979717602613707, 0.05361221258740831, 0.11501425309699129], [0.04695121980405198, -0.13053491609675175, 0.05025986885867986], [-0.09704684176098193, 0.03397687417738002, -0.1105886644677771], [0.14694697234804935, -0.12316902186157716, 0.04210404546699645], [0.14432470831243552, -0.002580008133591355, -0.08490676947390643], [0.051502750076553944, -0.10071695490292451, -0.01786223610178095], [-0.12503276881774464, 0.08877830923879379, 0.1076584501927316], [-0.020191205513213406, -0.1493425056303128, -0.14289740371758308], [-0.06470138952271293, -0.07410426095060325, 0.00980804676890873], [0.11747671720735695, 0.10916082743849789, -0.12235599365235904]]
-        latent_rgb_factors = [[-0.41, -0.25, -0.26],
-                              [-0.26, -0.49, -0.24],
-                              [-0.37, -0.54, -0.3],
-                              [-0.04, -0.29, -0.29],
-                              [-0.52, -0.59, -0.39],
-                              [-0.56, -0.6, -0.02],
-                              [-0.53, -0.06, -0.48],
-                              [-0.51, -0.28, -0.18],
-                              [-0.59, -0.1, -0.33],
-                              [-0.56, -0.54, -0.41],
-                              [-0.61, -0.19, -0.5],
-                              [-0.05, -0.25, -0.17],
-                              [-0.23, -0.04, -0.22],
-                              [-0.51, -0.56, -0.43],
-                              [-0.13, -0.4, -0.05],
-                              [-0.01, -0.01, -0.48]]
+        # latent_rgb_factors =[[-0.02531045419704009, -0.00504800612542497, 0.13293717293982546], [-0.03421835830845858, 0.13996708548892614, -0.07081038680118075], [0.011091819063647063, -0.03372949685846012, -0.0698232210116172], [-0.06276524604742019, -0.09322986677909442, 0.01826383612148913], [0.021290659938126788, -0.07719530444034409, -0.08247812477766273], [0.04401102991215147, -0.0026401932105894754, -0.01410913586718443], [0.08979717602613707, 0.05361221258740831, 0.11501425309699129], [0.04695121980405198, -0.13053491609675175, 0.05025986885867986], [-0.09704684176098193, 0.03397687417738002, -0.1105886644677771], [0.14694697234804935, -0.12316902186157716, 0.04210404546699645], [0.14432470831243552, -0.002580008133591355, -0.08490676947390643], [0.051502750076553944, -0.10071695490292451, -0.01786223610178095], [-0.12503276881774464, 0.08877830923879379, 0.1076584501927316], [-0.020191205513213406, -0.1493425056303128, -0.14289740371758308], [-0.06470138952271293, -0.07410426095060325, 0.00980804676890873], [0.11747671720735695, 0.10916082743849789, -0.12235599365235904]]
+        latent_rgb_factors = [
+            [-0.41, -0.25, -0.26],
+            [-0.26, -0.49, -0.24],
+            [-0.37, -0.54, -0.3],
+            [-0.04, -0.29, -0.29],
+            [-0.52, -0.59, -0.39],
+            [-0.56, -0.6, -0.02],
+            [-0.53, -0.06, -0.48],
+            [-0.51, -0.28, -0.18],
+            [-0.59, -0.1, -0.33],
+            [-0.56, -0.54, -0.41],
+            [-0.61, -0.19, -0.5],
+            [-0.05, -0.25, -0.17],
+            [-0.23, -0.04, -0.22],
+            [-0.51, -0.56, -0.43],
+            [-0.13, -0.4, -0.05],
+            [-0.01, -0.01, -0.48],
+        ]
 
         import random
+
         random.seed(seed)
-        #latent_rgb_factors = [[random.uniform(min_val, max_val) for _ in range(3)] for _ in range(16)]
+        # latent_rgb_factors = [[random.uniform(min_val, max_val) for _ in range(3)] for _ in range(16)]
         out_factors = latent_rgb_factors
         print(latent_rgb_factors)
 
-        #latent_rgb_factors_bias = [0.138, 0.025, -0.299]
+        # latent_rgb_factors_bias = [0.138, 0.025, -0.299]
         latent_rgb_factors_bias = [r_bias, g_bias, b_bias]
 
-        latent_rgb_factors = torch.tensor(latent_rgb_factors, device=latents.device, dtype=latents.dtype).transpose(0, 1)
-        latent_rgb_factors_bias = torch.tensor(latent_rgb_factors_bias, device=latents.device, dtype=latents.dtype)
+        latent_rgb_factors = torch.tensor(
+            latent_rgb_factors, device=latents.device, dtype=latents.dtype
+        ).transpose(0, 1)
+        latent_rgb_factors_bias = torch.tensor(
+            latent_rgb_factors_bias, device=latents.device, dtype=latents.dtype
+        )
 
         print("latent_rgb_factors", latent_rgb_factors.shape)
 
@@ -1472,18 +2312,19 @@ class HyVideoLatentPreview:
             latent = latents[:, :, t, :, :]
             latent = latent[0].permute(1, 2, 0)
             latent_image = torch.nn.functional.linear(
-                latent,
-                latent_rgb_factors,
-                bias=latent_rgb_factors_bias
+                latent, latent_rgb_factors, bias=latent_rgb_factors_bias
             )
             latent_images.append(latent_image)
         latent_images = torch.stack(latent_images, dim=0)
         print("latent_images", latent_images.shape)
         latent_images_min = latent_images.min()
         latent_images_max = latent_images.max()
-        latent_images = (latent_images - latent_images_min) / (latent_images_max - latent_images_min)
+        latent_images = (latent_images - latent_images_min) / (
+            latent_images_max - latent_images_min
+        )
 
         return (latent_images.float().cpu(), out_factors)
+
 
 NODE_CLASS_MAPPINGS = {
     "HyVideoSampler": HyVideoSampler,
@@ -1507,7 +2348,7 @@ NODE_CLASS_MAPPINGS = {
     "HyVideoContextOptions": HyVideoContextOptions,
     "HyVideoEnhanceAVideo": HyVideoEnhanceAVideo,
     "HyVideoTeaCache": HyVideoTeaCache,
-    }
+}
 NODE_DISPLAY_NAME_MAPPINGS = {
     "HyVideoSampler": "HunyuanVideo Sampler",
     "HyVideoDecode": "HunyuanVideo Decode",
@@ -1530,4 +2371,4 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "HyVideoContextOptions": "HunyuanVideo Context Options",
     "HyVideoEnhanceAVideo": "HunyuanVideo Enhance A Video",
     "HyVideoTeaCache": "HunyuanVideo TeaCache",
-    }
+}


### PR DESCRIPTION
## Add max_context_length to TextEncode node for LLM max tokens - experimental use

This PR adds `max_context_length` as a parameter (default of 256 as before) to enable additional tokens to be used for the LLM input prompt + prompt template + special tokens.

*   **`max_context_length` is now a node input with default of 256:** You can set it in the `DownloadAndLoadHyVideoTextEncoder` node.
    *   Defaults to 256, maxes out at 8192 (see: [https://huggingface.co/xtuner/llava-llama-3-8b-v1_1-transformers/blob/main/config.json](https://huggingface.co/xtuner/llava-llama-3-8b-v1_1-transformers/blob/main/config.json)).
    *   There's a tooltip with warnings of it being experimental and its impact on memory usage + possible performance issues in generation - but the memory impacts should be low given it's only doing a single inference
*   **Better handling of short `max_context_length`:**
    *   Added some debugs and a warning if you try to set `max_context_length` less than or equal to the crop_start value.
*   **Some debug logging to sanity check the input prompt + template + special tokens:**
    *   Set the logging to DEBUG in `nodes.py`
    *   When it's on, you'll see:
        *   The original prompt.
        *   The prompt with the template applied.
        *   Number of tokens used in the input.
        *   Logging when a prompt is too long and will be chopped.
        *   Tokenization details (shapes, attention mask).
        
**Testing Performed:**

*   **`max_context_length` = 256, Long Prompt:** Works as it did before, prompt gets truncated, no errors.
*   **`max_context_length` = 5, Long Prompt:**  Used to error out, now it runs with a warning and truncates.
*   **`max_context_length` = 512, Long Prompt > 512 tokens:** Works, prompt gets truncated (with a log message).
*   **`max_context_length` = 2048, Long Prompt of ~1700 tokens:** Works, prompt goes through fully.

**In short:** This makes the text encoder more flexible and easier to experiment with for longer input prompts and opens the door for few-shot examples. It's highly likely (with near certainty) that the model was trained with shorter inputs, likely right around the 256 default it was before. That said, autoregressive LLMs are always surprising, and it's very possible to end up in the same embedding space with a longer prompt with examples as you would have with a shorter one. Reminder changing this from the 256 default is experimental - it's locked at the max context window from the model config (8192) to avoid accidental way-too-high ones. It might be unstable with larger values, so test with caution. VRAM usage will increase if you increase it - only for a short burst, but if you're right on the edge of maxing out your VRAM, leave a little room before changing and only incrementally increase. Hopefully will see some cool possibilities from this. Thanks to Kijai as always for making a fantastic project for us all to experiment with.