### PR TITLE
Fixed device mismatch error with the Flow Edit Sampler node

### DIFF
--- a/hyvideo/modules/models.py
+++ b/hyvideo/modules/models.py
@@ -230,6 +230,8 @@ class MMDoubleStreamBlock(nn.Module):
 
         # Apply RoPE if needed.
         if freqs_cis is not None:
+            img_k = img_k.to(img_q.device)
+            freqs_cis = (freqs_cis[0].to(img_q.device), freqs_cis[1].to(img_q.device))
             img_q, img_k = apply_rotary_emb(img_q, img_k, freqs_cis, upcast=upcast_rope)
             
         # Prepare txt for attention.
@@ -400,6 +402,8 @@ class MMSingleStreamBlock(nn.Module):
         if freqs_cis is not None:
             img_q, txt_q = q[:, :-txt_len, :, :], q[:, -txt_len:, :, :]
             img_k, txt_k = k[:, :-txt_len, :, :], k[:, -txt_len:, :, :]
+            img_k = img_k.to(img_q.device)
+            freqs_cis = (freqs_cis[0].to(img_q.device), freqs_cis[1].to(img_q.device))
             img_q, img_k = apply_rotary_emb(img_q, img_k, freqs_cis, upcast=upcast_rope)
             # assert (
             #     img_qq.shape == img_q.shape and img_kk.shape == img_k.shape

--- a/hyvideo/modules/posemb_layers.py
+++ b/hyvideo/modules/posemb_layers.py
@@ -74,6 +74,7 @@ def apply_rotary_emb(
     freqs_cis: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
     upcast: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    device = xq.device  # Get the device of xq
     """
     Apply rotary embeddings to input tensors using the given frequency tensor.
 
@@ -93,7 +94,7 @@ def apply_rotary_emb(
     """
    
     shape = [d if i == 1 or i == xq.ndim - 1 else 1 for i, d in enumerate(xq.shape)]
-    cos, sin = freqs_cis[0].view(*shape), freqs_cis[1].view(*shape)
+    cos, sin = freqs_cis[0].to(device).view(*shape), freqs_cis[1].to(device).view(*shape)
 
     if upcast:
         xq_out = apply_rotary(xq.float(), cos, sin).to(xq.dtype)


### PR DESCRIPTION
Every time I tried to use the Flow Edit Sampler I would get a Fake Tensor device mismatch error, so I fixed it in the 2 files involved and the node seems to be working now in my tests.