### PR TITLE
Fix handling of cached input latents in img2vid

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1271,7 +1271,7 @@ class HyVideoSampler:
         #    print(name, param.data.device)
 
         leapfusion_img2vid = False
-        input_latents = samples["samples"] if samples is not None else None
+        input_latents = samples["samples"].clone() if samples is not None else None
         if input_latents is not None:
             if input_latents.shape[2] == 1:
                 leapfusion_img2vid = True


### PR DESCRIPTION
The vae factor was multiplied to the cached input latents every time the sampler gets executed. This PR fixes the issue.