### PR TITLE
Fix(requirements.txt): Fix transformers to mitigate breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 accelerate >= 1.2.1
 diffusers >= 0.31.0
-transformers >= 4.49.0
+transformers>=4.49.0,<=4.53.3
 jax >= 0.4.28
 timm >= 1.0.15


### PR DESCRIPTION
Pinning the transformers library to version 4.53.3 to avoid a breaking change introduced in version 4.54.0 that affects the ComfyUI-HunyuanVideoWrapper custom node. 

This change addresses the issues reported, such as the one in https://github.com/kijai/ComfyUI-HunyuanVideoWrapper/issues/497.

The transformers requirement has been updated from transformers>=4.49.0 to transformers>=4.49.0,<=4.53.3 to ensure compatibility while still allowing minor updates within a known stable range.